### PR TITLE
feat(auth): implement supabase auth logic

### DIFF
--- a/app/(investment)/crypto/page.tsx
+++ b/app/(investment)/crypto/page.tsx
@@ -1,0 +1,5 @@
+const Crypto = () => {
+  return <div>Crypto</div>;
+};
+
+export default Crypto;

--- a/app/(investment)/dashboard/page.tsx
+++ b/app/(investment)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+const Dashboard = () => {
+  return <div>Dashboard</div>;
+};
+
+export default Dashboard;

--- a/app/(investment)/layout.tsx
+++ b/app/(investment)/layout.tsx
@@ -1,0 +1,7 @@
+export default function InvestmentLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <>{children}</>;
+}

--- a/app/(investment)/stocks/page.tsx
+++ b/app/(investment)/stocks/page.tsx
@@ -1,0 +1,5 @@
+const Stocks = () => {
+  return <div>Stocks</div>;
+};
+
+export default Stocks;

--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -1,5 +1,0 @@
-const InputField = ({ name }) => {
-  return <div>InputField</div>;
-};
-
-export default InputField;

--- a/components/custom/auth/sign-in-form.tsx
+++ b/components/custom/auth/sign-in-form.tsx
@@ -2,8 +2,11 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { SignUpFormValues, signUpSchema } from "@/lib/schemas/sign-up";
 
+import { signInSchema, SignInFormValues } from "@/lib/schemas/sign-in";
+import { signIn } from "@/services/apiAuth";
+
+import { cn } from "@/lib/utils";
 import {
   Card,
   CardContent,
@@ -19,22 +22,27 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 const SignInForm = () => {
+  // react hook form + zod
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<SignUpFormValues>({
-    resolver: zodResolver(signUpSchema),
+  } = useForm<SignInFormValues>({
+    resolver: zodResolver(signInSchema),
     defaultValues: {
-      name: "",
       email: "",
+      password: "",
     },
   });
-  const onSubmit = async (data: SignUpFormValues) => {
-    console.log(data);
+
+  // onSubmit logic
+  const onSubmit = async (data: SignInFormValues) => {
+    const result = await signIn(data);
+    if (result?.error) {
+      alert(result.error);
+    }
   };
 
   return (

--- a/components/custom/auth/sign-up-form.tsx
+++ b/components/custom/auth/sign-up-form.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { SignUpFormValues, signUpSchema } from "@/lib/schemas/sign-up";
 import { zodResolver } from "@hookform/resolvers/zod";
+
+import { SignUpFormValues, signUpSchema } from "@/lib/schemas/sign-up";
+import { useRouter } from "next/navigation";
+import { signUp } from "@/services/apiAuth";
 
 import {
   Card,
@@ -21,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 const SignUpForm = () => {
+  // react hook form + zod
   const {
     register,
     handleSubmit,
@@ -34,8 +38,18 @@ const SignUpForm = () => {
       confirmPassword: "",
     },
   });
+
+  // onSubmit logic, redirect to /sign-in if success
+  const router = useRouter();
   const onSubmit = async (data: SignUpFormValues) => {
-    console.log(data);
+    const result = await signUp(data);
+    if (result.error) {
+      alert(
+        typeof result.error === "string" ? result.error : "Validation failed",
+      );
+    } else {
+      router.push("/sign-in");
+    }
   };
 
   return (
@@ -84,7 +98,7 @@ const SignUpForm = () => {
                 </p>
               ) : (
                 <FieldDescription>
-                  Must be at least 8 characters long.
+                  Must be at least 6 characters long.
                 </FieldDescription>
               )}
             </Field>

--- a/lib/schemas/sign-in.ts
+++ b/lib/schemas/sign-in.ts
@@ -1,3 +1,5 @@
+// SignIn Zod Validation rules
+
 import { z } from "zod";
 
 export const signInSchema = z.object({

--- a/lib/schemas/sign-up.ts
+++ b/lib/schemas/sign-up.ts
@@ -1,3 +1,5 @@
+// SignUp Zod Validation rules
+
 import { z } from "zod";
 
 export const signUpSchema = z

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,4 +1,4 @@
-//在浏览器里，随时创建一个已经连好 Supabase 的客户端
+//Browser-side Supabase client
 
 import { createBrowserClient } from "@supabase/ssr";
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-//在 Next.js 服务端，创建一个【能读写登录 Cookie】的 Supabase 客户端
+//Server-side Supabase Client-side
 
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
-    "@hookform/resolvers": "^5.2.2",
     "@phosphor-icons/react": "^2.1.10",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
@@ -26,15 +25,13 @@
     "react": "19.2.3",
     "react-day-picker": "^9.13.1",
     "react-dom": "19.2.3",
-    "react-hook-form": "^7.71.1",
     "react-resizable-panels": "^4.6.2",
     "recharts": "2.15.4",
     "shadcn": "^3.8.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2",
-    "zod": "^4.3.6"
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/services/apiAuth.ts
+++ b/services/apiAuth.ts
@@ -1,0 +1,60 @@
+"use server";
+
+//Server Action（ SignUp/SignIn Logic ）
+
+import { SignInFormValues, signInSchema } from "@/lib/schemas/sign-in";
+import { signUpSchema, SignUpFormValues } from "@/lib/schemas/sign-up";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+//
+export async function signUp(formatData: SignUpFormValues) {
+  //Zod Validation
+  const result = signUpSchema.safeParse(formatData);
+  if (!result.success) {
+    return {
+      error: result.error.format(),
+    };
+  }
+  const supabase = await createClient();
+
+  //Supabase API
+  const { error } = await supabase.auth.signUp({
+    email: formatData.email,
+    password: formatData.password,
+  });
+
+  if (error) {
+    return {
+      error: error.message,
+    };
+  }
+  return {
+    success: true,
+  };
+}
+
+// SignIn
+export async function signIn(formatData: SignInFormValues) {
+  const result = signInSchema.safeParse(formatData);
+  if (!result.success) {
+    return {
+      error: result.error.format(),
+    };
+  }
+
+  const supabase = await createClient();
+
+  //Supabase API
+  const { error } = await supabase.auth.signInWithPassword({
+    email: formatData.email,
+    password: formatData.password,
+  });
+
+  if (error) {
+    return {
+      error: error.message,
+    };
+  }
+  redirect("/dashboard");
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,9 +1,0 @@
-declare global {
-  type SignUpFormData = {
-    fullName: string;
-    email: string;
-    password: string;
-  };
-}
-
-export {};


### PR DESCRIPTION
## 概要

Supabase を使用して認証ロジックを実装しました。

## 実装内容

- Supabase クライアントの設定
- サインイン / サインアップ処理の実装
- エラーハンドリングの追加



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added investment section with Crypto, Dashboard, and Stocks pages
  * Implemented authentication sign-in and sign-up flows with API integration

* **Refactor**
  * Updated sign-up and sign-in forms to use actual API calls
  * Reduced password validation requirement from 8 to 6 characters minimum
  * Removed unused InputField component
  * Removed package dependencies

* **Documentation**
  * Updated code comments from Chinese to English for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->