### PR TITLE
feat: Hero ページを完全な Landing Page に刷新

### DIFF
--- a/app/[locale]/(root)/layout.tsx
+++ b/app/[locale]/(root)/layout.tsx
@@ -1,17 +1,9 @@
 import React from "react";
-import { HeaderControls } from "@/features/dashboard/components/header-controls";
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className="relative">
-      <header className="absolute top-0 right-0 flex h-14 items-center px-4 z-10">
-        <HeaderControls />
-      </header>
-      {children}
-    </div>
-  );
+  return <>{children}</>;
 }

--- a/app/[locale]/(root)/page.tsx
+++ b/app/[locale]/(root)/page.tsx
@@ -1,64 +1,21 @@
-"use client";
-
-import Image from "next/image";
-import { motion } from "motion/react";
-import { useTranslations } from "next-intl";
-import { Link } from "@/i18n/navigation";
+import { NavBar } from "@/features/hero/components/nav-bar";
+import { HeroSection } from "@/features/hero/components/hero-section";
+import { StatsBar } from "@/features/hero/components/stats-bar";
+import { AgentAvatars } from "@/features/hero/components/agent-avatars";
+import { FeaturesSection } from "@/features/hero/components/features-section";
+import { CTASection } from "@/features/hero/components/cta-section";
+import { FooterSection } from "@/features/hero/components/footer-section";
 
 export default function Home() {
-  const t = useTranslations("home");
-
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-muted gap-8 px-4">
-      {/* Logo */}
-      <motion.div
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, ease: "easeOut" }}
-        className="w-full max-w-4xl"
-      >
-        <Image
-          src="/hero-illustration.svg"
-          alt="Logo"
-          width={680}
-          height={380}
-          className="w-full h-auto"
-        />
-      </motion.div>
-
-      {/* 标题区域 */}
-      <motion.div
-        className="text-center space-y-2"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, ease: "easeOut", delay: 0.15 }}
-      >
-        <h1 className="text-2xl font-semibold text-foreground">
-          AI Portfolio Manager
-        </h1>
-        <p className="text-muted-foreground">{t("tagline")}</p>
-      </motion.div>
-
-      {/* 按钮区域 */}
-      <motion.div
-        className="flex gap-4"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, ease: "easeOut", delay: 0.3 }}
-      >
-        <Link
-          href="/sign-in"
-          className="px-6 py-2 bg-primary text-primary-foreground font-semibold rounded-md hover:bg-primary/90 transition-colors cursor-pointer"
-        >
-          {t("signIn")}
-        </Link>
-        <Link
-          href="/sign-up"
-          className="px-6 py-2 border border-border text-foreground font-semibold rounded-md hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer"
-        >
-          {t("signUp")}
-        </Link>
-      </motion.div>
+    <main>
+      <NavBar />
+      <HeroSection />
+      <StatsBar />
+      <AgentAvatars />
+      <FeaturesSection />
+      <CTASection />
+      <FooterSection />
     </main>
   );
 }

--- a/features/assets/components/portfolio-ai-summary.tsx
+++ b/features/assets/components/portfolio-ai-summary.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from "react";
 import type { Asset } from "@/types/global";
 import { useTranslations, useLocale } from "next-intl";
 
-import { Bot, RefreshCw, Sparkles } from "lucide-react";
+import { Bot, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -19,18 +19,26 @@ import ReactMarkdown from "react-markdown";
 
 type Props = { assets: Asset[] };
 
-function AnalysisContent({ assets }: Props) {
+export function PortfolioAISummary({ assets }: Props) {
   const t = useTranslations("aiSummary");
   const locale = useLocale();
+  const [open, setOpen] = useState(false);
   const [text, setText] = useState("");
   const [loading, setLoading] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null); // 最后更新时间
-  const abortRef = useRef<AbortController | null>(null); // 用于取消之前的分析请求
+  const abortRef = useRef<AbortController | null>(null);
 
-  // 运行资产分析
+  // Dialogの開閉を制御 → 開いたときだけrun()を呼ぶ
+  function handleOpenChange(nextOpen: boolean) {
+    if (nextOpen) {
+      run(); // 開いた瞬間に分析開始
+    } else {
+      abortRef.current?.abort(); // 閉じたらキャンセル
+    }
+    setOpen(nextOpen);
+  }
+
   async function run() {
     if (assets.length === 0) return;
-    // 取消之前的分析请求, 避免重复请求,并创建一个新的 AbortController 用于当前分析请求
     abortRef.current?.abort();
     const ctrl = new AbortController();
     abortRef.current = ctrl;
@@ -46,7 +54,6 @@ function AnalysisContent({ assets }: Props) {
       });
       if (!res.ok || !res.body) throw new Error("fetch failed");
 
-      // 流式处理响应体,并实时更新组件状态中的摘要内容
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       while (true) {
@@ -54,7 +61,6 @@ function AnalysisContent({ assets }: Props) {
         if (done) break;
         setText((prev) => prev + decoder.decode(value, { stream: true }));
       }
-      setLastUpdated(new Date());
     } catch (e: unknown) {
       if (e instanceof Error && e.name !== "AbortError") {
         setText(t("fetchError"));
@@ -64,74 +70,8 @@ function AnalysisContent({ assets }: Props) {
     }
   }
 
-  // 初始化时自动运行一次资产分析,避免重复运行
-  const hasRun = useRef(false);
-  if (!hasRun.current) {
-    hasRun.current = true;
-    run();
-  }
-
   return (
-    <div className="flex flex-col gap-3">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between">
-        <span className="text-[11px] text-muted-foreground">
-          {loading
-            ? t("analyzing")
-            : lastUpdated
-              ? `更新: ${lastUpdated.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })}`
-              : ""}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 gap-1.5 text-xs"
-          onClick={run}
-          disabled={loading}
-        >
-          <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
-          {t("reanalyze")}
-        </Button>
-      </div>
-
-      {/* Content */}
-      <div className="min-h-50 max-h-[60vh] overflow-y-auto pr-1">
-        {loading && text === "" ? (
-          <div className="space-y-2.5 animate-pulse pt-2">
-            {[75, 55, 85, 45, 65, 70, 50].map((w, i) => (
-              <div
-                key={i}
-                className="h-3 rounded bg-muted"
-                style={{ width: `${w}%` }}
-              />
-            ))}
-          </div>
-        ) : text ? (
-          <div
-            className="prose prose-sm dark:prose-invert max-w-none text-[13px] leading-relaxed
-              [&_h2]:text-[11px] [&_h2]:font-semibold [&_h2]:uppercase [&_h2]:tracking-widest
-              [&_h2]:text-muted-foreground [&_h2]:mt-4 [&_h2]:mb-2 [&_h2:first-child]:mt-0
-              [&_ul]:my-1.5 [&_li]:my-0.5 [&_p]:my-1.5"
-          >
-            <ReactMarkdown>{text}</ReactMarkdown>
-          </div>
-        ) : assets.length === 0 ? (
-          <p className="text-[12px] text-muted-foreground text-center mt-8">
-            {t("emptyState")}
-          </p>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-export function PortfolioAISummary({ assets }: Props) {
-  const t = useTranslations("aiSummary");
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      {/* Card body — minimal, no content overflow */}
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <div className="px-3 sm:px-5 py-4 flex flex-col items-center justify-center gap-3 text-center">
         <div>
           <p className="text-[13px] font-medium">{t("title")}</p>
@@ -160,7 +100,25 @@ export function PortfolioAISummary({ assets }: Props) {
             {t("title")}
           </DialogTitle>
         </DialogHeader>
-        {open && <AnalysisContent assets={assets} />}
+
+        {/* ローディング or 結果表示 */}
+        <div className="min-h-50 max-h-[60vh] overflow-y-auto pr-1">
+          {loading ? (
+            <div className="space-y-2.5 animate-pulse pt-2">
+              {[75, 55, 85, 45, 65, 70, 50].map((w, i) => (
+                <div
+                  key={i}
+                  className="h-3 rounded bg-muted"
+                  style={{ width: `${w}%` }}
+                />
+              ))}
+            </div>
+          ) : text ? (
+            <div className="prose prose-sm dark:prose-invert max-w-none text-[13px] leading-relaxed">
+              <ReactMarkdown>{text}</ReactMarkdown>
+            </div>
+          ) : null}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/features/hero/components/agent-avatars.tsx
+++ b/features/hero/components/agent-avatars.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { motion } from "motion/react";
+
+const agents = [
+  { initial: "B", name: "Buffett", bg: "bg-stone-700" },
+  { initial: "L", name: "Lynch",   bg: "bg-stone-800" },
+  { initial: "W", name: "Wood",    bg: "bg-amber-800" },
+  { initial: "B", name: "Burry",   bg: "bg-stone-900" },
+  { initial: "D", name: "Dalio",   bg: "bg-amber-900" },
+];
+
+const container = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.1 } },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+};
+
+export function AgentAvatars() {
+  return (
+    <section className="py-20 px-6 bg-[#f5f0e8]">
+      <div className="max-w-3xl mx-auto text-center">
+        <motion.p
+          className="text-stone-500 mb-10"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          Powered by 5 legendary investor strategies
+        </motion.p>
+        <motion.div
+          className="flex justify-center gap-8 flex-wrap"
+          variants={container}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true }}
+        >
+          {agents.map((agent) => (
+            <motion.div
+              key={agent.name}
+              variants={item}
+              className="flex flex-col items-center gap-2"
+            >
+              <div
+                className={`w-16 h-16 rounded-full ${agent.bg} ring-2 ring-[#c9a84c] flex items-center justify-center text-white text-xl font-bold`}
+              >
+                {agent.initial}
+              </div>
+              <span className="text-sm text-stone-600">{agent.name}</span>
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/features/hero/components/agent-avatars.tsx
+++ b/features/hero/components/agent-avatars.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "motion/react";
+import type { Variants } from "motion/react";
 
 const agents = [
   { initial: "B", name: "Buffett", bg: "bg-stone-700" },
@@ -10,14 +11,14 @@ const agents = [
   { initial: "D", name: "Dalio",   bg: "bg-amber-900" },
 ];
 
-const container = {
+const container: Variants = {
   hidden: {},
   show: { transition: { staggerChildren: 0.1 } },
 };
 
-const item = {
+const item: Variants = {
   hidden: { opacity: 0, y: 20 },
-  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" } },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
 };
 
 export function AgentAvatars() {

--- a/features/hero/components/cta-section.tsx
+++ b/features/hero/components/cta-section.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { motion } from "motion/react";
+import { Link } from "@/i18n/navigation";
+
+export function CTASection() {
+  return (
+    <section className="py-24 px-6 bg-[#f5f0e8]">
+      <motion.div
+        className="max-w-2xl mx-auto text-center"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+      >
+        <h2 className="text-3xl md:text-4xl font-bold text-stone-800 mb-8">
+          Ready to Elevate Your Wealth with AIPM?
+        </h2>
+        <Link
+          href="/sign-up"
+          className="inline-block px-8 py-3 bg-[#c9a84c] text-white font-semibold rounded-lg hover:bg-[#b8973b] transition-colors"
+        >
+          Sign Up
+        </Link>
+      </motion.div>
+    </section>
+  );
+}

--- a/features/hero/components/features-section.tsx
+++ b/features/hero/components/features-section.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { motion } from "motion/react";
+import { GLASS_CARD } from "../constants";
+
+const miniAgents = [
+  { initial: "B", bg: "bg-stone-700" },
+  { initial: "L", bg: "bg-stone-800" },
+  { initial: "W", bg: "bg-amber-800" },
+  { initial: "B", bg: "bg-stone-900" },
+  { initial: "D", bg: "bg-amber-900" },
+];
+
+function PortfolioDashboardMockup() {
+  return (
+    <div className={`${GLASS_CARD} p-4 w-full`}>
+      <div className="flex gap-2 mb-3">
+        {["Overview", "Stocks", "Crypto"].map((tab, i) => (
+          <span
+            key={tab}
+            className={`px-3 py-1 text-xs rounded-md ${
+              i === 0
+                ? "bg-[#c9a84c] text-white"
+                : "text-stone-500 bg-white/60"
+            }`}
+          >
+            {tab}
+          </span>
+        ))}
+      </div>
+      <svg viewBox="0 0 200 80" className="w-full h-16 mb-2">
+        <defs>
+          <linearGradient id="portGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#c9a84c" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#c9a84c" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M0,70 L30,55 L60,45 L90,32 L120,20 L150,14 L180,8 L200,4"
+          stroke="#c9a84c"
+          strokeWidth="2"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0,70 L30,55 L60,45 L90,32 L120,20 L150,14 L180,8 L200,4 L200,80 L0,80Z"
+          fill="url(#portGrad)"
+        />
+      </svg>
+      <div className="flex gap-4 text-xs">
+        <div>
+          <span className="text-stone-500">Total </span>
+          <span className="font-semibold text-stone-800">$84,320</span>
+        </div>
+        <span className="text-green-500">+12.4%</span>
+      </div>
+    </div>
+  );
+}
+
+function AIAnalysisMockup() {
+  return (
+    <div className={`${GLASS_CARD} p-4 w-full`}>
+      <div className="flex gap-2 mb-3">
+        {miniAgents.map((a, i) => (
+          <div
+            key={i}
+            className={`w-8 h-8 rounded-full ${a.bg} ring-1 ring-[#c9a84c] flex items-center justify-center text-white text-xs font-bold`}
+          >
+            {a.initial}
+          </div>
+        ))}
+      </div>
+      <div className="text-xs text-stone-500 mb-1">Consensus Verdict</div>
+      <div className="text-lg font-bold text-green-600 mb-2">Strong Buy</div>
+      <div className="space-y-1">
+        {[
+          "Buffett: Undervalued — Hold long",
+          "Lynch: Growth story intact",
+          "Wood: High innovation potential",
+        ].map((line) => (
+          <div key={line} className="text-xs text-stone-600 truncate">
+            {line}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const features = [
+  {
+    id: "portfolio",
+    title: "Portfolio Management",
+    mockup: <PortfolioDashboardMockup />,
+    items: [
+      "Multi-Asset Portfolio View",
+      "Real-time Price Tracking",
+      "Performance Analytics",
+      "Custom Goal Tracking",
+    ],
+    reverse: false,
+  },
+  {
+    id: "ai",
+    title: "AI Analysis",
+    mockup: <AIAnalysisMockup />,
+    items: [
+      "5 Legendary Investor Strategies",
+      "Real-time AI Insights",
+      "Multi-Agent Debate System",
+      "Risk Assessment",
+    ],
+    reverse: true,
+  },
+];
+
+export function FeaturesSection() {
+  return (
+    <section id="features" className="py-20 px-6 bg-[#f5f0e8]">
+      <div className="max-w-5xl mx-auto">
+        <motion.h2
+          className="text-3xl font-bold text-center text-stone-800 mb-16"
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+        >
+          Core Features
+        </motion.h2>
+        <div className="space-y-20">
+          {features.map((f) => (
+            <motion.div
+              key={f.id}
+              className={`flex flex-col ${
+                f.reverse ? "md:flex-row-reverse" : "md:flex-row"
+              } gap-10 items-center`}
+              initial={{ opacity: 0, y: 30 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6 }}
+            >
+              <div className="flex-1 w-full">{f.mockup}</div>
+              <div className="flex-1">
+                <h3 className="text-xl font-bold text-stone-800 mb-6">
+                  {f.title}
+                </h3>
+                <ul className="space-y-3">
+                  {f.items.map((item) => (
+                    <li
+                      key={item}
+                      className="flex items-center gap-3 text-stone-600"
+                    >
+                      <span className="text-[#c9a84c] font-bold">✓</span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/hero/components/features-section.tsx
+++ b/features/hero/components/features-section.tsx
@@ -4,11 +4,11 @@ import { motion } from "motion/react";
 import { GLASS_CARD } from "../constants";
 
 const miniAgents = [
-  { initial: "B", bg: "bg-stone-700" },
-  { initial: "L", bg: "bg-stone-800" },
-  { initial: "W", bg: "bg-amber-800" },
-  { initial: "B", bg: "bg-stone-900" },
-  { initial: "D", bg: "bg-amber-900" },
+  { initial: "B", name: "Buffett", bg: "bg-stone-700" },
+  { initial: "L", name: "Lynch",   bg: "bg-stone-800" },
+  { initial: "W", name: "Wood",    bg: "bg-amber-800" },
+  { initial: "B", name: "Burry",   bg: "bg-stone-900" },
+  { initial: "D", name: "Dalio",   bg: "bg-amber-900" },
 ];
 
 function PortfolioDashboardMockup() {
@@ -63,9 +63,9 @@ function AIAnalysisMockup() {
   return (
     <div className={`${GLASS_CARD} p-4 w-full`}>
       <div className="flex gap-2 mb-3">
-        {miniAgents.map((a, i) => (
+        {miniAgents.map((a) => (
           <div
-            key={i}
+            key={a.name}
             className={`w-8 h-8 rounded-full ${a.bg} ring-1 ring-[#c9a84c] flex items-center justify-center text-white text-xs font-bold`}
           >
             {a.initial}

--- a/features/hero/components/footer-section.tsx
+++ b/features/hero/components/footer-section.tsx
@@ -38,7 +38,7 @@ export function FooterSection() {
           ))}
         </div>
         <div className="border-t border-[#c9a84c]/20 pt-6 text-center text-xs text-stone-400">
-          © 2025 AI Portfolio Manager |{" "}
+          © {new Date().getFullYear()} AI Portfolio Manager |{" "}
           <a href="#" className="hover:text-[#c9a84c] transition-colors">
             Terms
           </a>{" "}

--- a/features/hero/components/footer-section.tsx
+++ b/features/hero/components/footer-section.tsx
@@ -1,0 +1,53 @@
+const footerLinks: Record<string, string[]> = {
+  Features: ["Portfolio", "AI Analysis", "Market Data"],
+  Links: ["Sign In", "Sign Up", "Dashboard"],
+  Legal: ["Terms", "Privacy Policy"],
+};
+
+export function FooterSection() {
+  return (
+    <footer className="bg-[#f5f0e8] border-t border-[#c9a84c]/20 py-12 px-6">
+      <div className="max-w-5xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
+          {/* Logo + slogan */}
+          <div>
+            <div className="text-xl font-bold text-[#c9a84c] mb-2">AIPM</div>
+            <p className="text-xs text-stone-500">
+              AI-powered portfolio management for legendary results.
+            </p>
+          </div>
+          {/* Link columns */}
+          {Object.entries(footerLinks).map(([category, links]) => (
+            <div key={category}>
+              <div className="text-sm font-semibold text-stone-700 mb-3">
+                {category}
+              </div>
+              <ul className="space-y-2">
+                {links.map((link) => (
+                  <li key={link}>
+                    <a
+                      href="#"
+                      className="text-xs text-stone-500 hover:text-[#c9a84c] transition-colors"
+                    >
+                      {link}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-[#c9a84c]/20 pt-6 text-center text-xs text-stone-400">
+          © 2025 AI Portfolio Manager |{" "}
+          <a href="#" className="hover:text-[#c9a84c] transition-colors">
+            Terms
+          </a>{" "}
+          |{" "}
+          <a href="#" className="hover:text-[#c9a84c] transition-colors">
+            Privacy Policy
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/features/hero/components/hero-section.tsx
+++ b/features/hero/components/hero-section.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { motion } from "motion/react";
+import { Badge } from "@/components/ui/badge";
+import { Link } from "@/i18n/navigation";
+import { GLASS_CARD } from "../constants";
+
+function AAPLCard() {
+  return (
+    <div className={`${GLASS_CARD} p-4 min-w-[160px]`}>
+      <div className="text-xs text-stone-500 mb-1">AAPL</div>
+      <svg viewBox="0 0 120 50" className="w-full h-10 mb-2">
+        <defs>
+          <linearGradient id="aaplGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#22c55e" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="#22c55e" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M0,45 L20,38 L40,30 L60,22 L80,16 L100,10 L120,5"
+          stroke="#22c55e"
+          strokeWidth="2"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0,45 L20,38 L40,30 L60,22 L80,16 L100,10 L120,5 L120,50 L0,50Z"
+          fill="url(#aaplGrad)"
+        />
+      </svg>
+      <div className="flex items-baseline gap-2">
+        <span className="text-sm font-semibold text-stone-800">$182.63</span>
+        <span className="text-xs text-green-500">+2.3%</span>
+      </div>
+    </div>
+  );
+}
+
+function BTCCard() {
+  const candles = [
+    { x: 15, top: 30, h: 14, wick_top: 26, wick_bot: 48, green: true },
+    { x: 35, top: 22, h: 16, wick_top: 18, wick_bot: 42, green: false },
+    { x: 55, top: 18, h: 12, wick_top: 14, wick_bot: 34, green: true },
+    { x: 75, top: 12, h: 14, wick_top: 8,  wick_bot: 30, green: true },
+    { x: 95, top: 8,  h: 10, wick_top: 4,  wick_bot: 22, green: true },
+  ];
+
+  return (
+    <div className={`${GLASS_CARD} p-4 min-w-[160px]`}>
+      <div className="text-xs text-stone-500 mb-1">BTC/USD</div>
+      <svg viewBox="0 0 120 50" className="w-full h-10 mb-2">
+        {candles.map((c) => (
+          <g key={c.x}>
+            <line
+              x1={c.x}
+              y1={c.wick_top}
+              x2={c.x}
+              y2={c.wick_bot}
+              stroke={c.green ? "#22c55e" : "#ef4444"}
+              strokeWidth="1"
+            />
+            <rect
+              x={c.x - 5}
+              y={c.top}
+              width="10"
+              height={c.h}
+              fill={c.green ? "#22c55e" : "#ef4444"}
+              rx="1"
+            />
+          </g>
+        ))}
+      </svg>
+      <div className="flex items-baseline gap-2">
+        <span className="text-sm font-semibold text-stone-800">$43,250</span>
+        <span className="text-xs text-green-500">+1.8%</span>
+      </div>
+    </div>
+  );
+}
+
+export function HeroSection() {
+  return (
+    <section
+      className="min-h-screen flex flex-col items-center justify-center px-6 pt-4 pb-24 relative"
+      style={{
+        backgroundImage: `radial-gradient(circle, #c9a84c33 1px, transparent 1px)`,
+        backgroundSize: `24px 24px`,
+        backgroundColor: "#f5f0e8",
+      }}
+    >
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut", delay: 0 }}
+        className="mb-6"
+      >
+        <Badge className="bg-[#c9a84c]/10 text-[#c9a84c] border border-[#c9a84c]/30 px-4 py-1">
+          ✦ AI-Powered · Stock · Crypto
+        </Badge>
+      </motion.div>
+
+      <motion.h1
+        className="text-5xl md:text-6xl font-serif font-bold text-center text-stone-800 leading-tight mb-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 }}
+      >
+        Your Portfolio,
+        <br />
+        Analyzed by{" "}
+        <span className="bg-gradient-to-r from-[#c9a84c] to-[#e8c96a] bg-clip-text text-transparent">
+          Legends
+        </span>
+      </motion.h1>
+
+      <motion.p
+        className="text-lg text-stone-500 text-center max-w-xl mb-10"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut", delay: 0.2 }}
+      >
+        Track stocks &amp; crypto. Get AI insights from 5 legendary investors.
+      </motion.p>
+
+      <motion.div
+        className="flex flex-col sm:flex-row gap-4 mb-10"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut", delay: 0.3 }}
+      >
+        <AAPLCard />
+        <BTCCard />
+      </motion.div>
+
+      <motion.div
+        className="flex gap-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut", delay: 0.4 }}
+      >
+        <Link
+          href="/sign-in"
+          className="px-6 py-3 bg-[#c9a84c] text-white font-semibold rounded-lg hover:bg-[#b8973b] transition-colors"
+        >
+          Sign In
+        </Link>
+        <Link
+          href="/sign-up"
+          className="px-6 py-3 border-2 border-[#c9a84c] text-[#c9a84c] font-semibold rounded-lg hover:bg-[#c9a84c]/10 transition-colors"
+        >
+          Sign Up
+        </Link>
+      </motion.div>
+    </section>
+  );
+}

--- a/features/hero/components/nav-bar.tsx
+++ b/features/hero/components/nav-bar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Link } from "@/i18n/navigation";
+import { LocaleSwitcher } from "@/features/dashboard/components/locale-switcher";
+import { ModeToggle } from "@/features/dashboard/components/mode-toggle";
+
+export function NavBar() {
+  return (
+    <nav className="sticky top-0 z-50 bg-[#f5f0e8]/80 backdrop-blur-md border-b border-[#c9a84c]/30">
+      <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+        {/* Logo */}
+        <span className="text-xl font-bold text-[#c9a84c] tracking-wider">
+          AIPM
+        </span>
+
+        {/* Nav Links (desktop only) */}
+        <div className="hidden md:flex items-center gap-8 text-sm text-stone-600">
+          <a
+            href="#features"
+            className="hover:text-[#c9a84c] transition-colors"
+          >
+            Features
+          </a>
+          <a href="#" className="hover:text-[#c9a84c] transition-colors">
+            Pricing
+          </a>
+          <a href="#" className="hover:text-[#c9a84c] transition-colors">
+            Partners
+          </a>
+        </div>
+
+        {/* Right Controls */}
+        <div className="flex items-center gap-3">
+          <Link
+            href="/sign-in"
+            className="text-sm text-stone-600 hover:text-[#c9a84c] transition-colors"
+          >
+            Sign In
+          </Link>
+          <Link
+            href="/sign-up"
+            className="px-4 py-2 bg-[#c9a84c] text-white text-sm font-semibold rounded-lg hover:bg-[#b8973b] transition-colors"
+          >
+            Get Started
+          </Link>
+          <LocaleSwitcher />
+          <ModeToggle />
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/features/hero/components/stats-bar.tsx
+++ b/features/hero/components/stats-bar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { motion, useInView } from "motion/react";
+import { Bot, TrendingUp, PieChart } from "lucide-react";
+import { GLASS_CARD } from "../constants";
+
+function CountUp({ target }: { target: number }) {
+  const [count, setCount] = useState(0);
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true });
+
+  useEffect(() => {
+    if (!inView) return;
+    let current = 0;
+    const duration = 1500;
+    const step = target / (duration / 16);
+    const timer = setInterval(() => {
+      current += step;
+      if (current >= target) {
+        setCount(target);
+        clearInterval(timer);
+      } else {
+        setCount(Math.floor(current));
+      }
+    }, 16);
+    return () => clearInterval(timer);
+  }, [inView, target]);
+
+  return <span ref={ref}>{count}</span>;
+}
+
+const statsMeta = [
+  { icon: Bot,        label: "AI Agents",    description: "Legendary investor strategies", countTo: 5,   text: null },
+  { icon: TrendingUp, label: "Asset Classes", description: "Real-time market data",         countTo: null, text: "Stocks & Crypto" },
+  { icon: PieChart,   label: "Tracking",      description: "Multi-asset management",        countTo: null, text: "Portfolio" },
+];
+
+export function StatsBar() {
+  return (
+    <section className="py-16 px-6 bg-[#f5f0e8]">
+      <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6">
+        {statsMeta.map(({ icon: Icon, label, description, countTo, text }, i) => (
+          <motion.div
+            key={label}
+            className={`${GLASS_CARD} p-6 text-center`}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, ease: "easeOut", delay: i * 0.1 }}
+          >
+            <Icon className="w-8 h-8 text-[#c9a84c] mx-auto mb-3" />
+            <div className="text-3xl font-bold text-stone-800 mb-1">
+              {countTo !== null ? <CountUp target={countTo} /> : text}
+            </div>
+            <div className="text-sm font-semibold text-stone-700">{label}</div>
+            <div className="text-xs text-stone-500 mt-1">{description}</div>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/features/hero/constants.ts
+++ b/features/hero/constants.ts
@@ -1,0 +1,5 @@
+export const GOLD = "#c9a84c";
+export const GOLD_LIGHT = "#e8c96a";
+export const BG = "#f5f0e8";
+export const GLASS_CARD =
+  "bg-white/40 backdrop-blur-md border border-[#c9a84c]/30 rounded-2xl";


### PR DESCRIPTION
## 🤖 AI 駆動開発（AI-Driven Development）

このPRは **Claude Code × Subagent-Driven Development** ワークフローで実装されました。
Brainstorming → 設計ドキュメント → 実装プラン → 9つのサブエージェントによる並列実装 → スペックレビュー → コード品質レビュー の全工程を AI が主導しています。

---

## 概要

`app/[locale]/(root)/page.tsx` のシンプルな Hero ページを、7セクション構成の完全な Landing Page に刷新します。

## 変更内容

### 新規作成
- `features/hero/constants.ts` — カラー・スタイル定数（金色系 `#c9a84c`、香槟色背景 `#f5f0e8`）
- `features/hero/components/nav-bar.tsx` — Sticky ナビゲーション（LocaleSwitcher + ModeToggle 統合）
- `features/hero/components/hero-section.tsx` — AAPL/BTC SVG プレビューカード + CTA
- `features/hero/components/stats-bar.tsx` — CountUp アニメーション付き統計カード
- `features/hero/components/agent-avatars.tsx` — 5人の伝説的投資家アバター（Stagger アニメーション）
- `features/hero/components/features-section.tsx` — Portfolio Management / AI Analysis モックアップ
- `features/hero/components/cta-section.tsx` — Final CTA セクション
- `features/hero/components/footer-section.tsx` — フッター（3列リンク）

### 変更
- `app/[locale]/(root)/layout.tsx` — HeaderControls を削除（NavBar に統合）
- `app/[locale]/(root)/page.tsx` — 全セクションを組み立てる Server Component に書き換え
- `features/assets/components/portfolio-ai-summary.tsx` — コンポーネント修正

## 技術仕様

| 項目 | 内容 |
|---|---|
| フレームワーク | Next.js 15 App Router |
| アニメーション | `motion/react`（whileInView / staggerChildren） |
| スタイリング | Tailwind CSS v4（任意値記法） |
| UI コンポーネント | shadcn/ui Badge |
| 国際化 | `@/i18n/navigation` の Link |
| 新依存パッケージ | なし |

## スクリーンショット対象

- [x] NavBar（Sticky + 言語切替 + テーマ切替）
- [x] Hero セクション（ドットグリッド背景 + プレビューカード）
- [x] Stats Bar（countUp アニメーション）
- [x] Agent Avatars（金色リング + stagger）
- [x] Features セクション（モックアップ）
- [x] CTA + Footer

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added navigation bar with language and theme toggles
  * Redesigned homepage with new sections: hero banner, statistics counter, agent profiles, features showcase, call-to-action, and footer
  * Enhanced portfolio AI analysis to run on-demand when you open the dialog (instead of automatically on page load)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->