### PR TITLE
feat: UI全体のカラーテーマ統一・レイアウト改善

### DIFF
--- a/app/[locale]/dashboard/assets/page.tsx
+++ b/app/[locale]/dashboard/assets/page.tsx
@@ -27,8 +27,8 @@ export default async function Assets() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2.5 mb-1">
-            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-500/10">
-              <LayoutDashboard className="h-4 w-4 text-amber-500" />
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+              <LayoutDashboard className="h-4 w-4 text-primary" />
             </span>
             <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
           </div>
@@ -44,7 +44,7 @@ export default async function Assets() {
           <TotalAssetCard assets={list} />
         </div>
         <div className="sm:col-span-1">
-        <WidgetCard icon={Bot} title={t("aiSummaryWidget")} accent="amber">
+        <WidgetCard icon={Bot} title={t("aiSummaryWidget")} accent="primary">
           <PortfolioAISummary assets={list} />
         </WidgetCard>
         </div>
@@ -62,7 +62,7 @@ export default async function Assets() {
           <WidgetCard
             icon={Newspaper}
             title={t("dailyAnalysisWidget")}
-            accent="violet"
+            accent="primary"
           >
             <DailyAnalysis assets={list} />
           </WidgetCard>
@@ -74,7 +74,7 @@ export default async function Assets() {
         icon={Database}
         title={t("allAssetsWidget")}
         badge={list.length > 0 ? `${list.length}` : undefined}
-        accent="blue"
+        accent="primary"
         action={
           <AssetForm trigger={<Button size="sm">{t("addAsset")}</Button>} />
         }

--- a/app/[locale]/dashboard/stocks/page.tsx
+++ b/app/[locale]/dashboard/stocks/page.tsx
@@ -32,8 +32,8 @@ export default async function Stocks() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2.5 mb-1">
-            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-violet-500/10">
-              <Activity className="h-4 w-4 text-violet-500" />
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+              <Activity className="h-4 w-4 text-primary" />
             </span>
             <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
           </div>
@@ -44,8 +44,8 @@ export default async function Stocks() {
 
         {/* stat chips */}
         <div className="flex flex-wrap gap-2">
-          <StatChip icon={Globe} label={t("globalData")} accent="blue" />
-          <StatChip icon={Zap} label={t("liveUpdates")} accent="amber" />
+          <StatChip icon={Globe} label={t("globalData")} accent="primary" />
+          <StatChip icon={Zap} label={t("liveUpdates")} accent="primary" />
         </div>
       </div>
 
@@ -54,7 +54,7 @@ export default async function Stocks() {
         icon={Radio}
         title={t("liveTicker")}
         badge={t("streaming")}
-        accent="amber"
+        accent="primary"
       >
         <div className="py-2 px-4">
           <TickerTape />
@@ -66,7 +66,7 @@ export default async function Stocks() {
         icon={TrendingUp}
         title={t("liveChart")}
         badge="AAPL"
-        accent="violet"
+        accent="primary"
         className="h-165"
       >
         <div className="h-full p-4">
@@ -92,7 +92,7 @@ export default async function Stocks() {
           icon={Newspaper}
           title={t("topStories")}
           badge="News"
-          accent="blue"
+          accent="primary"
           className="xl:h-140"
         >
           <div className="h-full p-4">
@@ -106,7 +106,7 @@ export default async function Stocks() {
         icon={BarChart2}
         title={t("marketData")}
         badge="Market Data"
-        accent="emerald"
+        accent="primary"
         className="h-130"
       >
         <div className="h-full p-4">

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,47 +173,47 @@
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.15 0 0);
 
-  /* ── 主色：纯净蓝 ── */
-  --primary: oklch(0.55 0.18 250);
+  /* ── 主色：琥珀金（dark テーマと同色） ── */
+  --primary: oklch(0.6724 0.1308 38.7559);
   --primary-foreground: oklch(1 0 0);
 
   /* ── 次色 ── */
-  --secondary: oklch(0.95 0 0);
-  --secondary-foreground: oklch(0.2 0 0);
+  --secondary: oklch(0.95 0.01 70);
+  --secondary-foreground: oklch(0.2 0.02 50);
 
   /* ── 静音色 ── */
-  --muted: oklch(0.96 0 0);
-  --muted-foreground: oklch(0.5 0 0);
+  --muted: oklch(0.96 0.005 70);
+  --muted-foreground: oklch(0.5 0.02 55);
 
   /* ── 强调色 ── */
-  --accent: oklch(0.93 0 0);
-  --accent-foreground: oklch(0.2 0 0);
+  --accent: oklch(0.93 0.02 65);
+  --accent-foreground: oklch(0.2 0.02 50);
 
   /* ── 危险色 ── */
   --destructive: oklch(0.57 0.19 25);
   --destructive-foreground: oklch(1 0 0);
 
   /* ── 边框 / 输入框 / 焦点环 ── */
-  --border: oklch(0.88 0 0);
-  --input: oklch(0.92 0 0);
-  --ring: oklch(0.55 0.18 250);
+  --border: oklch(0.88 0.01 65);
+  --input: oklch(0.92 0.01 68);
+  --ring: oklch(0.6724 0.1308 38.7559);
 
   /* ── 图表色 ── */
-  --chart-1: oklch(0.55 0.18 250);
-  --chart-2: oklch(0.65 0.15 180);
-  --chart-3: oklch(0.75 0.12 140);
-  --chart-4: oklch(0.6 0.16 310);
-  --chart-5: oklch(0.7 0.14 60);
+  --chart-1: oklch(0.5583 0.1276 42.9956);
+  --chart-2: oklch(0.6898 0.1581 290.4107);
+  --chart-3: oklch(0.8816 0.0276 93.128);
+  --chart-4: oklch(0.8822 0.0403 298.1792);
+  --chart-5: oklch(0.5608 0.1348 42.0584);
 
   /* ── 侧边栏 ── */
-  --sidebar: oklch(0.98 0 0);
-  --sidebar-foreground: oklch(0.2 0 0);
-  --sidebar-primary: oklch(0.55 0.18 250);
+  --sidebar: oklch(0.98 0.005 70);
+  --sidebar-foreground: oklch(0.2 0.02 50);
+  --sidebar-primary: oklch(0.6724 0.1308 38.7559);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.94 0 0);
-  --sidebar-accent-foreground: oklch(0.2 0 0);
-  --sidebar-border: oklch(0.88 0 0);
-  --sidebar-ring: oklch(0.55 0.18 250);
+  --sidebar-accent: oklch(0.94 0.02 65);
+  --sidebar-accent-foreground: oklch(0.2 0.02 50);
+  --sidebar-border: oklch(0.88 0.01 65);
+  --sidebar-ring: oklch(0.6724 0.1308 38.7559);
 
   --radius: 0.625rem;
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "h-5 gap-1 rounded-none border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
+  "h-5 gap-1 rounded-md border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
   {
     variants: {
       variant: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-none border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {
@@ -19,12 +19,12 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        xs: "h-6 gap-1 rounded-none px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-none px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-md px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
         icon: "size-8",
-        "icon-xs": "size-6 rounded-none [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-7 rounded-none",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-7 rounded-md",
         "icon-lg": "size-9",
       },
     },

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -11,7 +11,7 @@ function Card({
     <div
       data-slot="card"
       data-size={size}
-      className={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-none py-4 text-xs/relaxed ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-2 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-none *:[img:last-child]:rounded-none group/card flex flex-col", className)}
+      className={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-xs/relaxed ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-2 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-xl *:[img:last-child]:rounded-xl group/card flex flex-col", className)}
       {...props}
     />
   )
@@ -22,7 +22,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "gap-1 rounded-none px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+        "gap-1 rounded-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
         className
       )}
       {...props}
@@ -77,7 +77,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("rounded-none border-t p-4 group-data-[size=sm]/card:p-3 flex items-center", className)}
+      className={cn("rounded-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center", className)}
       {...props}
     />
   )

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-none p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-none border bg-transparent px-2.5 py-1 text-xs transition-colors file:h-6 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-xs file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-md border bg-transparent px-2.5 py-1 text-xs transition-colors file:h-6 file:text-xs file:font-medium focus-visible:ring-1 aria-invalid:ring-1 md:text-xs file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -24,7 +24,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "rounded-none p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col",
+  "rounded-md p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col",
   {
     variants: {
       variant: {
@@ -58,9 +58,9 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "gap-1.5 rounded-none border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-vertical/tabs:py-[calc(--spacing(1.25))] [&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "gap-1.5 rounded-sm border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-vertical/tabs:py-[calc(--spacing(1.25))] [&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+        "data-active:bg-background data-active:border-border data-active:shadow-sm dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className
       )}

--- a/features/ai/components/analysis-shell.tsx
+++ b/features/ai/components/analysis-shell.tsx
@@ -93,8 +93,8 @@ export function AnalysisShell() {
     <div className="p-3 sm:p-6 space-y-4 sm:space-y-6">
       <div>
         <div className="flex items-center gap-2.5 mb-1">
-          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-500/10">
-            <Brain className="h-4 w-4 text-blue-500" />
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+            <Brain className="h-4 w-4 text-primary" />
           </span>
           <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
         </div>

--- a/features/ai/components/search-bar.tsx
+++ b/features/ai/components/search-bar.tsx
@@ -75,7 +75,7 @@ export function SearchBar({ onAnalyze, isLoading, disabled }: SearchBarProps) {
   return (
     <div className="flex flex-col sm:flex-row gap-2">
       <div className="flex-1">
-        <Command className="border rounded-3xl" shouldFilter={false}>
+        <Command className="border rounded-md" shouldFilter={false}>
           <div className="flex items-center px-6">
             {/* 搜索中显示加载动画，否则显示搜索图标 */}
             {isFetching ? (
@@ -134,7 +134,7 @@ export function SearchBar({ onAnalyze, isLoading, disabled }: SearchBarProps) {
       <Button
         onClick={handleSubmit}
         disabled={disabled || isLoading || !(selectedSymbol || query.trim())}
-        className="rounded-3xl px-6 w-full sm:w-auto sm:self-start sm:mt-0.5"
+        className="px-6 w-full sm:w-auto sm:self-start sm:mt-0.5"
       >
         {isLoading ? "Loading..." : "Analyze"}
       </Button>

--- a/features/assets/components/portfolio-ai-summary.tsx
+++ b/features/assets/components/portfolio-ai-summary.tsx
@@ -83,7 +83,7 @@ export function PortfolioAISummary({ assets }: Props) {
           render={
             <Button
               size="sm"
-              className="gap-1.5 bg-amber-500 hover:bg-amber-600 text-white"
+              className="gap-1.5 bg-primary hover:bg-primary/90 text-primary-foreground"
               disabled={assets.length === 0}
             />
           }
@@ -96,7 +96,7 @@ export function PortfolioAISummary({ assets }: Props) {
       <DialogContent className="w-[95vw] max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-base">
-            <Bot className="h-4 w-4 text-violet-500" />
+            <Bot className="h-4 w-4 text-primary" />
             {t("title")}
           </DialogTitle>
         </DialogHeader>

--- a/features/assets/components/portfolio-candlestick-chart.tsx
+++ b/features/assets/components/portfolio-candlestick-chart.tsx
@@ -329,7 +329,7 @@ export function PortfolioCandlestickChart({ assets, allTransactions }: Props) {
     >
       {/* WidgetCard header */}
       <div className="flex flex-wrap items-center gap-2 px-3 sm:px-5 py-3 sm:py-3.5 border-b border-border/60">
-        <span className="flex items-center justify-center h-7 w-7 rounded-lg shrink-0 bg-violet-500/10 text-violet-500 dark:bg-violet-400/10 dark:text-violet-400">
+        <span className="flex items-center justify-center h-7 w-7 rounded-lg shrink-0 bg-primary/10 text-primary">
           <TrendingUp className="h-4 w-4" />
         </span>
         <span className="text-sm font-semibold tracking-tight flex-1 truncate">

--- a/features/assets/components/total-asset-card.tsx
+++ b/features/assets/components/total-asset-card.tsx
@@ -72,7 +72,7 @@ export function TotalAssetCard({ assets }: Props) {
       transition={{ duration: 0.45, ease: "easeOut" as const }}
     >
       <div className="flex items-center gap-3 px-3 sm:px-5 py-3.5 border-b border-border/60">
-        <span className="flex items-center justify-center h-7 w-7 rounded-lg shrink-0 bg-amber-500/10 text-amber-500 dark:bg-amber-400/10 dark:text-amber-400">
+        <span className="flex items-center justify-center h-7 w-7 rounded-lg shrink-0 bg-primary/10 text-primary">
           <Wallet className="h-4 w-4" />
         </span>
         <span className="text-sm font-semibold tracking-tight">

--- a/features/assets/components/transaction-form.tsx
+++ b/features/assets/components/transaction-form.tsx
@@ -118,18 +118,18 @@ export function TransactionForm({
               )}
             />
 
-            <div className="flex gap-4">
+            <div className="grid grid-cols-3 gap-4">
               {/* Quantity：自定义加减按钮 + 原生 number input */}
               <Controller
                 name="quantity"
                 control={form.control}
                 render={({ field, fieldState }) => (
-                  <Field data-invalid={fieldState.invalid} className="flex-1">
+                  <Field data-invalid={fieldState.invalid} className="min-w-0">
                     <FieldLabel>Quantity</FieldLabel>
-                    <div className="flex items-center border rounded-md">
+                    <div className="flex items-center border rounded-md h-8">
                       <button
                         type="button"
-                        className="px-3 py-2 hover:bg-muted"
+                        className="px-3 h-full hover:bg-muted"
                         // Math.max(1, ...) 防止数量减到 0 或负数
                         onClick={() =>
                           field.onChange(Math.max(1, Number(field.value) - 1))
@@ -156,7 +156,7 @@ export function TransactionForm({
                       />
                       <button
                         type="button"
-                        className="px-3 py-2 hover:bg-muted"
+                        className="px-3 h-full hover:bg-muted"
                         onClick={() => field.onChange(Number(field.value) + 1)}
                       >
                         <Plus className="w-4 h-4" />
@@ -174,7 +174,7 @@ export function TransactionForm({
                 name="traded_at"
                 control={form.control}
                 render={({ field, fieldState }) => (
-                  <Field data-invalid={fieldState.invalid} className="flex-1">
+                  <Field data-invalid={fieldState.invalid} className="min-w-0">
                     <FieldLabel>
                       {currentType === "buy" ? "Purchase Date" : "Sell Date"}
                     </FieldLabel>
@@ -185,7 +185,7 @@ export function TransactionForm({
                             variant="outline"
                             className="w-full justify-start"
                           >
-                            <CalendarIcon className="mr-2 w-4 h-4" />
+                            <CalendarIcon className="w-4 h-4" />
                             {field.value ? field.value : "Select date"}
                           </Button>
                         }
@@ -226,7 +226,7 @@ export function TransactionForm({
                 name="price"
                 control={form.control}
                 render={({ field, fieldState }) => (
-                  <Field data-invalid={fieldState.invalid} className="flex-1">
+                  <Field data-invalid={fieldState.invalid} className="min-w-0">
                     <FieldLabel>
                       {currentType === "buy" ? "Purchase Price" : "Sell Price"}
                     </FieldLabel>

--- a/features/crypto/components/crypto-market-dashboard.tsx
+++ b/features/crypto/components/crypto-market-dashboard.tsx
@@ -166,8 +166,8 @@ export function CryptoMarketDashboard() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2.5 mb-1">
-            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-amber-500/10">
-              <Activity className="h-4.5 w-4.5 text-amber-500" />
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+              <Activity className="h-4.5 w-4.5 text-primary" />
             </span>
             <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
           </div>
@@ -178,13 +178,8 @@ export function CryptoMarketDashboard() {
 
         {/* stat chips */}
         <div className="flex flex-wrap gap-2">
-          <StatChip icon={Globe} label={t("globalData")} accent="blue" />
-          <StatChip icon={Zap} label={t("liveUpdates")} accent="amber" />
-          <StatChip
-            icon={TrendingUp}
-            label={t("top100Coins")}
-            accent="emerald"
-          />
+          <StatChip icon={Globe} label={t("globalData")} accent="primary" />
+          <StatChip icon={Zap} label={t("liveUpdates")} accent="primary" />
         </div>
       </div>
 
@@ -193,7 +188,7 @@ export function CryptoMarketDashboard() {
         icon={TrendingUp}
         title={t("livePrices")}
         badge={t("streaming")}
-        accent="amber"
+        accent="primary"
       >
         <MarqueeWidget />
       </WidgetCard>
@@ -204,7 +199,7 @@ export function CryptoMarketDashboard() {
           icon={LineChart}
           title={t("coinCompareChart")}
           badge="BTC"
-          accent="violet"
+          accent="primary"
           className="xl:h-145"
         >
           <CoinCompareChartWidget />
@@ -214,7 +209,7 @@ export function CryptoMarketDashboard() {
           icon={Flame}
           title={t("marketHeatmap")}
           badge="Top 100"
-          accent="orange"
+          accent="primary"
           className="xl:h-145"
         >
           <HeatmapWidget />
@@ -227,7 +222,7 @@ export function CryptoMarketDashboard() {
           icon={ArrowLeftRight}
           title={t("converter")}
           badge="BTC / USD"
-          accent="emerald"
+          accent="primary"
           className="lg:col-span-2"
           contentClassName="overflow-visible"
         >
@@ -238,7 +233,7 @@ export function CryptoMarketDashboard() {
           icon={BarChart2}
           title={t("topCoins")}
           badge="12 Assets"
-          accent="blue"
+          accent="primary"
           className="lg:col-span-1"
           contentClassName="overflow-visible"
         >

--- a/features/dashboard/components/mode-toggle.tsx
+++ b/features/dashboard/components/mode-toggle.tsx
@@ -24,7 +24,6 @@ export function ModeToggle() {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
-        bg-background
         align="end"
         className="rounded-xl p-1.5 min-w-32.5"
       >

--- a/features/dashboard/components/widget-card.tsx
+++ b/features/dashboard/components/widget-card.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
    Icon accent colours
 ───────────────────────────────────────── */
 export const iconStyles = {
+  primary: "bg-primary/10 text-primary",
   amber:
     "bg-amber-500/10 text-amber-500 dark:bg-amber-400/10 dark:text-amber-400",
   violet:

--- a/features/hero/components/features-section.tsx
+++ b/features/hero/components/features-section.tsx
@@ -37,10 +37,10 @@ const features = [
 
 export function FeaturesSection() {
   return (
-    <section id="features" className="py-20 px-6 bg-[#f5f0e8]">
+    <section id="features" className="py-20 px-6 bg-background">
       <div className="max-w-5xl mx-auto">
         <motion.h2
-          className="text-3xl font-bold text-center text-stone-800 mb-4"
+          className="text-3xl font-bold text-center text-foreground mb-4"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -49,7 +49,7 @@ export function FeaturesSection() {
           Core Features
         </motion.h2>
         <motion.p
-          className="text-stone-500 text-center mb-14"
+          className="text-muted-foreground text-center mb-14"
           initial={{ opacity: 0, y: 20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -68,7 +68,7 @@ export function FeaturesSection() {
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
             >
-              <div className="relative w-full aspect-video bg-stone-100">
+              <div className="relative w-full aspect-video bg-muted">
                 <Image
                   src={f.image}
                   alt={f.title}
@@ -78,10 +78,10 @@ export function FeaturesSection() {
                 />
               </div>
               <div className="p-5">
-                <h3 className="text-base font-bold text-stone-800 mb-2">
+                <h3 className="text-base font-bold text-foreground mb-2">
                   {f.title}
                 </h3>
-                <p className="text-sm text-stone-500 leading-relaxed">
+                <p className="text-sm text-muted-foreground leading-relaxed">
                   {f.description}
                 </p>
               </div>

--- a/features/hero/components/footer-section.tsx
+++ b/features/hero/components/footer-section.tsx
@@ -1,52 +1,15 @@
-const footerLinks: Record<string, string[]> = {
-  Features: ["Portfolio", "AI Analysis", "Market Data"],
-  Links: ["Sign In", "Sign Up", "Dashboard"],
-  Legal: ["Terms", "Privacy Policy"],
-};
-
 export function FooterSection() {
   return (
-    <footer className="bg-[#f5f0e8] border-t border-[#c9a84c]/20 py-12 px-6">
-      <div className="max-w-5xl mx-auto">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-8">
-          {/* Logo + slogan */}
-          <div>
-            <div className="text-xl font-bold text-[#c9a84c] mb-2">AIPM</div>
-            <p className="text-xs text-stone-500">
-              AI-powered portfolio management for legendary results.
-            </p>
-          </div>
-          {/* Link columns */}
-          {Object.entries(footerLinks).map(([category, links]) => (
-            <div key={category}>
-              <div className="text-sm font-semibold text-stone-700 mb-3">
-                {category}
-              </div>
-              <ul className="space-y-2">
-                {links.map((link) => (
-                  <li key={link}>
-                    <a
-                      href="#"
-                      className="text-xs text-stone-500 hover:text-[#c9a84c] transition-colors"
-                    >
-                      {link}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-        <div className="border-t border-[#c9a84c]/20 pt-6 text-center text-xs text-stone-400">
-          © {new Date().getFullYear()} AI Portfolio Manager |{" "}
-          <a href="#" className="hover:text-[#c9a84c] transition-colors">
-            Terms
-          </a>{" "}
-          |{" "}
-          <a href="#" className="hover:text-[#c9a84c] transition-colors">
-            Privacy Policy
-          </a>
-        </div>
+    <footer className="bg-[#f5f0e8] border-t border-[#c9a84c]/20 py-6 px-6">
+      <div className=" border-[#c9a84c]/20 pt-6 text-center text-xs text-stone-400">
+        © {new Date().getFullYear()} AI Portfolio Manager |{" "}
+        <a href="#" className="hover:text-[#c9a84c] transition-colors">
+          Terms
+        </a>{" "}
+        |{" "}
+        <a href="#" className="hover:text-[#c9a84c] transition-colors">
+          Privacy Policy
+        </a>
       </div>
     </footer>
   );

--- a/features/hero/components/hero-section.tsx
+++ b/features/hero/components/hero-section.tsx
@@ -43,11 +43,10 @@ function TvChartCard({ symbol }: { symbol: string }) {
 export function HeroSection() {
   return (
     <section
-      className="min-h-screen flex flex-col items-center justify-center px-6 pt-4 pb-24 relative"
+      className="min-h-screen flex flex-col items-center justify-center px-6 pt-4 pb-24 relative bg-background"
       style={{
-        backgroundImage: `radial-gradient(circle, #c9a84c33 1px, transparent 1px)`,
+        backgroundImage: `radial-gradient(circle, color-mix(in oklch, var(--primary) 20%, transparent) 1px, transparent 1px)`,
         backgroundSize: `24px 24px`,
-        backgroundColor: "#f5f0e8",
       }}
     >
       <motion.div
@@ -56,13 +55,13 @@ export function HeroSection() {
         transition={{ duration: 0.5, ease: "easeOut", delay: 0 }}
         className="mb-6"
       >
-        <Badge className="bg-[#c9a84c]/10 text-[#c9a84c] border border-[#c9a84c]/30 px-4 py-1">
+        <Badge className="bg-primary/10 text-primary border border-primary/30 px-4 py-1">
           ✦ AI-Powered · Stock · Crypto
         </Badge>
       </motion.div>
 
       <motion.h1
-        className="text-5xl md:text-6xl font-serif font-bold text-center text-stone-800 leading-tight mb-4"
+        className="text-5xl md:text-6xl font-serif font-bold text-center text-foreground leading-tight mb-4"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 }}
@@ -70,13 +69,13 @@ export function HeroSection() {
         Your Portfolio,
         <br />
         Analyzed by{" "}
-        <span className="bg-linear-to-r from-[#c9a84c] to-[#e8c96a] bg-clip-text text-transparent">
+        <span className="bg-linear-to-r from-primary to-primary/60 bg-clip-text text-transparent">
           Legends
         </span>
       </motion.h1>
 
       <motion.p
-        className="text-lg text-stone-500 text-center max-w-xl mb-10"
+        className="text-lg text-muted-foreground text-center max-w-xl mb-10"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: "easeOut", delay: 0.2 }}
@@ -92,13 +91,13 @@ export function HeroSection() {
       >
         <Link
           href="/sign-in"
-          className="px-6 py-3 bg-[#c9a84c] text-white font-semibold rounded-lg hover:bg-[#b8973b] transition-colors"
+          className="px-6 py-3 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary/90 transition-colors"
         >
           Sign In
         </Link>
         <Link
           href="/sign-up"
-          className="px-6 py-3 border-2 border-[#c9a84c] text-[#c9a84c] font-semibold rounded-lg hover:bg-[#c9a84c]/10 transition-colors"
+          className="px-6 py-3 border-2 border-primary text-primary font-semibold rounded-lg hover:bg-primary/10 transition-colors"
         >
           Sign Up
         </Link>

--- a/features/hero/components/nav-bar.tsx
+++ b/features/hero/components/nav-bar.tsx
@@ -6,42 +6,39 @@ import { ModeToggle } from "@/features/dashboard/components/mode-toggle";
 
 export function NavBar() {
   return (
-    <nav className="sticky top-0 z-50 bg-[#f5f0e8]/80 backdrop-blur-md border-b border-[#c9a84c]/30">
-      <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
+    <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-primary/30">
+      <div className="px-4 h-16 flex items-center">
         {/* Logo */}
-        <span className="text-xl font-bold text-[#c9a84c] tracking-wider">
+        <span className="text-xl font-bold text-primary tracking-wider px-2">
           AIPM
         </span>
 
-        {/* Nav Links (desktop only) */}
-        <div className="hidden md:flex items-center gap-8 text-sm text-stone-600">
-          <a
-            href="#features"
-            className="hover:text-[#c9a84c] transition-colors"
-          >
+        {/* Nav Links (desktop only) — centered */}
+        <div className="flex-1 hidden md:flex justify-center items-center gap-8 text-sm text-muted-foreground">
+          <a href="#features" className="hover:text-primary transition-colors">
             Features
           </a>
-          <a href="#" className="hover:text-[#c9a84c] transition-colors">
+          <a href="#" className="hover:text-primary transition-colors">
             About Developers
           </a>
         </div>
 
-        {/* Right Controls */}
-        <div className="flex items-center gap-3">
+        {/* Right Controls — flush right */}
+        <div className="hidden md:flex items-center gap-4 ml-auto">
+          <LocaleSwitcher />
+          <ModeToggle />
           <Link
             href="/sign-in"
-            className="text-sm text-stone-600 hover:text-[#c9a84c] transition-colors"
+            className="text-sm text-muted-foreground hover:text-primary transition-colors"
           >
             Sign In
           </Link>
           <Link
             href="/sign-up"
-            className="px-4 py-2 bg-[#c9a84c] text-white text-sm font-semibold rounded-lg hover:bg-[#b8973b] transition-colors"
+            className="px-4 py-2 bg-primary text-primary-foreground text-sm font-semibold rounded-lg hover:bg-primary/90 transition-colors"
           >
             Get Started
           </Link>
-          <LocaleSwitcher />
-          <ModeToggle />
         </div>
       </div>
     </nav>

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -101,7 +101,7 @@
       "subtitle": "リアルタイム価格・ヒートマップ・チャート・換算ツール",
       "globalData": "グローバルデータ",
       "liveUpdates": "リアルタイム更新",
-      "top100Coins": "上位100コイン",
+
       "livePrices": "ライブ価格",
       "streaming": "ストリーミング",
       "coinCompareChart": "コイン比較チャート",


### PR DESCRIPTION
# 概要

このPRは、Claude Codeを用いたAI駆動開発ワークフローによって全て作成されました。すべての設計判断・コード変更・リファクタリングは自然言語の指示を通じて実行され、AIアシスト型フロントエンド開発の可能性を実証しています。

## 変更部分

### 🎨 カラーテーマの統一
- **アンバーゴールドをプライマリカラーに統一:** `white` テーマの `--primary` をブルー（`oklch(0.55 0.18 250)`）からアンバーゴールド（`oklch(0.6724 0.1308 38.7559)`）に変更し、`dark` テーマと同一の配色に統合
- **全ダッシュボードページのアイコン・バッジを `accent="primary"` に統一:** Assets・Stocks・Crypto・AI ページのヘッダーアイコン、StatChip、WidgetCard をすべてアンバー系に変更
- **`widget-card.tsx` に `primary` アクセントタイプを追加**

### 🔲 UIコンポーネントの角丸統一
- `button.tsx`・`badge.tsx`・`dialog.tsx`・`input.tsx`・`card.tsx`・`tabs.tsx` の `rounded-none` をすべて `rounded-md` / `rounded-xl` に変更し、カード全体のデザインと統一

### 🏠 ヒーローページのテーマ対応
- `hero-section.tsx`・`features-section.tsx`・`nav-bar.tsx` のハードコードされた hex カラーをすべて CSS 変数クラス（`bg-background`・`text-foreground`・`text-primary` 等）に置き換え、テーマ切り替えに対応
- ドットパターン背景を `color-mix(in oklch, var(--primary) 20%, transparent)` でテーマ連動に変更

### 🧭 NavBar レイアウト改善
- `Sign In`・`Get Started` を右側に移動し、`EN | ☀️ | Sign In | Get Started` の並びに統一
- `ml-auto` でコントロールを画面右端にフラッシュ配置（ダッシュボードヘッダーと同様）

### 📝 フォームレイアウト修正（Transaction Form）
- `flex gap-4` → `grid grid-cols-3 gap-4` に変更し、Buy/Sell の各カラム幅を均等化
- ダイアログ幅を `sm:max-w-sm` → `sm:max-w-md` に拡大

### 🧹 クリーンアップ
- `footer-section.tsx` のリンクセクションを削除
- `mode-toggle.tsx` の不要な `bg-background` 属性を除去

## AI駆動開発について

このセッション全体を通じて、Claude Codeにより実施されました：

- UI/UXの判断はユーザーからの自然言語フィードバックを受けながら反復的に行われました
- コンポーネントの作成・リファクタリング・削除はすべてリアルタイムのユーザー指示に基づいて実行されました

---

🤖 *Claude Code によって生成*