### PR TITLE
feat: ダッシュボードにユーザーアバター・設定・ドロップダウンUIを追加

### DIFF
--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -52,7 +52,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-none p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}
@@ -97,7 +97,7 @@ function AlertDialogMedia({
   return (
     <div
       data-slot="alert-dialog-media"
-      className={cn("bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-none sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6", className)}
+      className={cn("bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-lg sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6", className)}
       {...props}
     />
   )

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-none shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 dark z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-xl shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 dark z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden p-1",
             className,
           )}
           {...props}
@@ -91,7 +91,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-none px-2 py-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-md px-2 py-1.5 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -116,7 +116,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-none px-2 py-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 data-popup-open:bg-accent data-popup-open:text-accent-foreground flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-md px-2 py-1.5 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 data-popup-open:bg-accent data-popup-open:text-accent-foreground flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -165,7 +165,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-none py-2 pr-8 pl-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       checked={checked}
@@ -206,7 +206,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-none py-2 pr-8 pl-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}

--- a/features/assets/server/assets.ts
+++ b/features/assets/server/assets.ts
@@ -104,6 +104,19 @@ export async function deleteAsset(id: string) {
   revalidatePath("/dashboard/assets");
 }
 
+// 当前ユーザーのすべての資産を削除
+export async function deleteAllAssets() {
+  const { supabase, user } = await getAuthSession();
+
+  const { error } = await supabase
+    .from("assets")
+    .delete()
+    .eq("user_id", user.id);
+
+  if (error) throw new Error(error.message);
+  revalidatePath("/dashboard/assets");
+}
+
 // 更新资产
 export async function updateAsset(id: string, rawData: unknown) {
   const { supabase, user } = await getAuthSession();

--- a/features/auth/server/auth.ts
+++ b/features/auth/server/auth.ts
@@ -67,3 +67,18 @@ export async function signIn(formatData: unknown) {
 
   redirect("/dashboard/assets");
 }
+
+export async function signOut() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  redirect("/sign-in");
+}
+
+export async function changePassword(newPassword: string) {
+  const supabase = await createClient();
+  const { error } = await supabase.auth.updateUser({ password: newPassword });
+  if (error) {
+    return { error: "パスワードの変更に失敗しました。もう一度お試しください。" };
+  }
+  return { success: true };
+}

--- a/features/dashboard/components/header-controls.tsx
+++ b/features/dashboard/components/header-controls.tsx
@@ -1,11 +1,22 @@
 import { ModeToggle } from "@/features/dashboard/components/mode-toggle";
 import { LocaleSwitcher } from "@/features/dashboard/components/locale-switcher";
+import { UserAvatar } from "@/features/dashboard/components/user-avatar";
+import { getAuthSession } from "@/features/auth/server/auth-helper";
 
-export function HeaderControls() {
+export async function HeaderControls() {
+  let email: string | null = null;
+  try {
+    const { user } = await getAuthSession();
+    email = user.email ?? null;
+  } catch {
+    // セッションなし（ログアウト中など）はアバターを表示しない
+  }
+
   return (
     <div className="flex items-center gap-2">
       <LocaleSwitcher />
       <ModeToggle />
+      {email && <UserAvatar email={email} />}
     </div>
   );
 }

--- a/features/dashboard/components/settings-modal.tsx
+++ b/features/dashboard/components/settings-modal.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { deleteAllAssets } from "@/features/assets/server/assets";
+import { changePassword } from "@/features/auth/server/auth";
+
+interface SettingsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+
+  async function handleDeleteAll() {
+    setIsDeleting(true);
+    try {
+      await deleteAllAssets();
+      toast.success("ポートフォリオデータをすべて削除しました");
+      setConfirmDeleteOpen(false);
+      onOpenChange(false);
+    } catch {
+      toast.error("削除に失敗しました。もう一度お試しください。");
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  async function handleChangePassword(e: React.FormEvent) {
+    e.preventDefault();
+    if (newPassword.length < 6) {
+      toast.error("パスワードは6文字以上で設定してください");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      toast.error("パスワードが一致しません");
+      return;
+    }
+    setIsChangingPassword(true);
+    try {
+      const result = await changePassword(newPassword);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("パスワードを変更しました");
+        setNewPassword("");
+        setConfirmPassword("");
+      }
+    } catch {
+      toast.error("パスワードの変更に失敗しました");
+    } finally {
+      setIsChangingPassword(false);
+    }
+  }
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>設定</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <p className="text-sm font-medium">ポートフォリオデータ</p>
+              <p className="text-xs text-muted-foreground">
+                現在のポートフォリオにある全てのデータを削除します。この操作は取り消せません。
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="w-fit"
+                onClick={() => setConfirmDeleteOpen(true)}
+              >
+                全データを削除
+              </Button>
+            </div>
+
+            <Separator />
+
+            <form onSubmit={handleChangePassword} className="flex flex-col gap-2">
+              <p className="text-sm font-medium">パスワード変更</p>
+              <Input
+                type="password"
+                placeholder="新しいパスワード（6文字以上）"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                autoComplete="new-password"
+              />
+              <Input
+                type="password"
+                placeholder="新しいパスワード（確認）"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                autoComplete="new-password"
+              />
+              <Button
+                type="submit"
+                size="sm"
+                className="w-fit"
+                disabled={isChangingPassword}
+              >
+                {isChangingPassword ? "変更中..." : "パスワードを変更"}
+              </Button>
+            </form>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>本当に削除しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              ポートフォリオ内の全ての資産と取引履歴が完全に削除されます。この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel variant="outline" size="default" disabled={isDeleting}>
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleDeleteAll}
+              disabled={isDeleting}
+            >
+              {isDeleting ? "削除中..." : "削除する"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/features/dashboard/components/user-avatar.tsx
+++ b/features/dashboard/components/user-avatar.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { Settings, LogOut } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { signOut } from "@/features/auth/server/auth";
+import { SettingsModal } from "./settings-modal";
+
+interface UserAvatarProps {
+  email: string;
+}
+
+export function UserAvatar({ email }: UserAvatarProps) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const initial = email.charAt(0).toUpperCase();
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger>
+          <div className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-amber-500 text-white text-sm font-semibold select-none hover:bg-amber-600 transition-colors">
+            {initial}
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" side="bottom">
+          <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
+            <Settings />
+            設定
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => signOut()}>
+            <LogOut />
+            ログアウト
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <SettingsModal open={settingsOpen} onOpenChange={setSettingsOpen} />
+    </>
+  );
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -49,7 +49,8 @@ export async function updateSession(request: NextRequest) {
   if (
     !user &&
     !pathname.includes("/sign-in") &&
-    !pathname.includes("/sign-up")
+    !pathname.includes("/sign-up") &&
+    !pathname.startsWith("/auth/")
   ) {
     const url = request.nextUrl.clone();
     url.pathname = `/${locale}/sign-in`;


### PR DESCRIPTION
# 概要

このPRは、Claude Codeを用いたAI駆動開発ワークフローによって全て作成されました。すべての設計判断・コード変更・バグ修正は自然言語の指示を通じて実行され、AIアシスト型フロントエンド開発の可能性を実証しています。

## 変更部分

### 👤 ユーザーアバター（ヘッダー右上）
- ログインユーザーのメールアドレス頭文字をアンバー円形で表示
- `HeaderControls` を async Server Component に変更し、`getAuthSession()` でメールを取得
- 未認証時（ログアウト遷移中）はアバターを非表示にしてエラーを防止

### 📋 ドロップダウンメニュー
- アバタークリックで「設定」「ログアウト」のドロップダウンを表示
- `signOut()` Server Action を新規追加（Supabase セッション削除 → `/sign-in` リダイレクト）

### ⚙️ 設定モーダル
- **ポートフォリオデータ一括削除:** 削除ボタン → AlertDialog で二重確認 → `deleteAllAssets()` 実行
- **パスワード変更:** 新パスワード・確認パスワードの入力フォーム（6文字以上・一致チェック）→ `changePassword()` 実行
- 処理結果は Sonner Toast で通知

### 🎨 ドロップダウン・AlertDialog の角丸スタイル統一
- `DropdownMenuContent`: `rounded-none` → `rounded-xl`（+ `p-1` 内側余白）
- `DropdownMenuItem` 各種: `rounded-none` → `rounded-md`
- `AlertDialogContent`: `rounded-none` → `rounded-xl`
- アプリ全体の角丸デザイン（カード `rounded-xl`、ボタン `rounded-md`）と統一

### 🐛 Google OAuth 認証バグ修正
- `/auth/callback` にアクセス時、未ログイン判定で `locale` が `"auth"` に誤抽出される問題を修正
- `/auth/sign-in`（存在しないルート）への誤リダイレクト → 404 が発生していた
- `updateSession` の認証ガードに `!pathname.startsWith("/auth/")` 条件を追加して解決

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `features/dashboard/components/user-avatar.tsx` | アバター + ドロップダウン（Client Component） |
| `features/dashboard/components/settings-modal.tsx` | 設定モーダル（Client Component） |

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `features/auth/server/auth.ts` | `signOut`・`changePassword` Server Action を追加 |
| `features/assets/server/assets.ts` | `deleteAllAssets` Server Action を追加 |
| `features/dashboard/components/header-controls.tsx` | async 化・UserAvatar 組み込み |
| `lib/supabase/middleware.ts` | `/auth/` パスを認証ガードから除外 |
| `components/ui/dropdown-menu.tsx` | 角丸スタイルを `rounded-xl` / `rounded-md` に変更 |
| `components/ui/alert-dialog.tsx` | 角丸スタイルを `rounded-xl` に変更 |

## AI駆動開発について

このセッション全体を通じて、Claude Codeにより実施されました：

- UI/UXの判断はユーザーからの自然言語フィードバックを受けながら反復的に行われました
- コンポーネントの作成・Server Action の追加・バグ修正はすべてリアルタイムのユーザー指示に基づいて実行されました
- Google OAuth のデバッグもミドルウェアのコード解析によりAIが根本原因を特定しました

---

🤖 *Claude Code によって生成*