### PR TITLE
feat: プロジェクト名変更・NavBar改善・設定UI国際化

### DIFF
--- a/app/[locale]/(auth)/layout.tsx
+++ b/app/[locale]/(auth)/layout.tsx
@@ -1,5 +1,5 @@
 import AuthLayoutWrapper from "@/features/auth/components/auth-layout-wrapper";
-import { HeaderControls } from "@/features/dashboard/components/header-controls";
+import { NavBar } from "@/features/hero/components/nav-bar";
 
 import { TrendingUp, ShieldCheck, BotMessageSquare } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -24,9 +24,7 @@ export default async function layout({
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="flex h-14 shrink-0 items-center justify-end border-b px-4">
-        <HeaderControls />
-      </header>
+      <NavBar />
       <div className="flex flex-1">
         {/* ── Left branding panel (desktop only) ── */}
         <div className="hidden lg:flex lg:w-[45%] bg-sidebar flex-col justify-between p-12 relative overflow-hidden border-r border-sidebar-border">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "AI Portfolio Manager",
+  title: "PortfolioX",
   description: "Track your stocks and crypto with AI-powered insights",
 };
 

--- a/features/auth/server/auth.ts
+++ b/features/auth/server/auth.ts
@@ -74,11 +74,25 @@ export async function signOut() {
   redirect("/sign-in");
 }
 
-export async function changePassword(newPassword: string) {
+export async function changePassword(currentPassword: string, newPassword: string) {
   const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) {
+    return { errorCode: "userNotFound" };
+  }
+
+  const { error: verifyError } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: currentPassword,
+  });
+  if (verifyError) {
+    return { errorCode: "invalidCurrentPassword" };
+  }
+
   const { error } = await supabase.auth.updateUser({ password: newPassword });
   if (error) {
-    return { error: "パスワードの変更に失敗しました。もう一度お試しください。" };
+    return { errorCode: "updateFailed" };
   }
   return { success: true };
 }

--- a/features/dashboard/components/settings-modal.tsx
+++ b/features/dashboard/components/settings-modal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import {
   Dialog,
   DialogContent,
@@ -30,8 +31,10 @@ interface SettingsModalProps {
 }
 
 export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
+  const t = useTranslations("settings");
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [isChangingPassword, setIsChangingPassword] = useState(false);
@@ -40,11 +43,11 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
     setIsDeleting(true);
     try {
       await deleteAllAssets();
-      toast.success("ポートフォリオデータをすべて削除しました");
+      toast.success(t("toast.deleteSuccess"));
       setConfirmDeleteOpen(false);
       onOpenChange(false);
     } catch {
-      toast.error("削除に失敗しました。もう一度お試しください。");
+      toast.error(t("toast.deleteFailed"));
     } finally {
       setIsDeleting(false);
     }
@@ -52,26 +55,31 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
 
   async function handleChangePassword(e: React.FormEvent) {
     e.preventDefault();
+    if (!currentPassword) {
+      toast.error(t("toast.currentPasswordRequired"));
+      return;
+    }
     if (newPassword.length < 6) {
-      toast.error("パスワードは6文字以上で設定してください");
+      toast.error(t("toast.passwordTooShort"));
       return;
     }
     if (newPassword !== confirmPassword) {
-      toast.error("パスワードが一致しません");
+      toast.error(t("toast.passwordMismatch"));
       return;
     }
     setIsChangingPassword(true);
     try {
-      const result = await changePassword(newPassword);
-      if (result.error) {
-        toast.error(result.error);
+      const result = await changePassword(currentPassword, newPassword);
+      if ("errorCode" in result && result.errorCode) {
+        toast.error(t(`toast.${result.errorCode}`));
       } else {
-        toast.success("パスワードを変更しました");
+        toast.success(t("toast.passwordChanged"));
+        setCurrentPassword("");
         setNewPassword("");
         setConfirmPassword("");
       }
     } catch {
-      toast.error("パスワードの変更に失敗しました");
+      toast.error(t("toast.passwordChangeFailed"));
     } finally {
       setIsChangingPassword(false);
     }
@@ -82,14 +90,14 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>設定</DialogTitle>
+            <DialogTitle>{t("title")}</DialogTitle>
           </DialogHeader>
 
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">
-              <p className="text-sm font-medium">ポートフォリオデータ</p>
+              <p className="text-sm font-medium">{t("portfolioData.title")}</p>
               <p className="text-xs text-muted-foreground">
-                現在のポートフォリオにある全てのデータを削除します。この操作は取り消せません。
+                {t("portfolioData.description")}
               </p>
               <Button
                 variant="destructive"
@@ -97,24 +105,31 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 className="w-fit"
                 onClick={() => setConfirmDeleteOpen(true)}
               >
-                全データを削除
+                {t("portfolioData.deleteButton")}
               </Button>
             </div>
 
             <Separator />
 
             <form onSubmit={handleChangePassword} className="flex flex-col gap-2">
-              <p className="text-sm font-medium">パスワード変更</p>
+              <p className="text-sm font-medium">{t("password.title")}</p>
               <Input
                 type="password"
-                placeholder="新しいパスワード（6文字以上）"
+                placeholder={t("password.currentPassword")}
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                autoComplete="current-password"
+              />
+              <Input
+                type="password"
+                placeholder={t("password.newPassword")}
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
                 autoComplete="new-password"
               />
               <Input
                 type="password"
-                placeholder="新しいパスワード（確認）"
+                placeholder={t("password.confirmPassword")}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 autoComplete="new-password"
@@ -125,7 +140,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                 className="w-fit"
                 disabled={isChangingPassword}
               >
-                {isChangingPassword ? "変更中..." : "パスワードを変更"}
+                {isChangingPassword ? t("password.changing") : t("password.submit")}
               </Button>
             </form>
           </div>
@@ -135,21 +150,21 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
       <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>本当に削除しますか？</AlertDialogTitle>
+            <AlertDialogTitle>{t("portfolioData.confirmTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              ポートフォリオ内の全ての資産と取引履歴が完全に削除されます。この操作は取り消せません。
+              {t("portfolioData.confirmDescription")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel variant="outline" size="default" disabled={isDeleting}>
-              キャンセル
+              {t("portfolioData.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
               onClick={handleDeleteAll}
               disabled={isDeleting}
             >
-              {isDeleting ? "削除中..." : "削除する"}
+              {isDeleting ? t("portfolioData.deleting") : t("portfolioData.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/features/dashboard/components/user-avatar.tsx
+++ b/features/dashboard/components/user-avatar.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Settings, LogOut } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,6 +18,7 @@ interface UserAvatarProps {
 }
 
 export function UserAvatar({ email }: UserAvatarProps) {
+  const t = useTranslations("settings.dropdown");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const initial = email.charAt(0).toUpperCase();
 
@@ -31,12 +33,12 @@ export function UserAvatar({ email }: UserAvatarProps) {
         <DropdownMenuContent align="end" side="bottom">
           <DropdownMenuItem onClick={() => setSettingsOpen(true)}>
             <Settings />
-            設定
+            {t("settings")}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onClick={() => signOut()}>
             <LogOut />
-            ログアウト
+            {t("signOut")}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/features/hero/components/hero-section.tsx
+++ b/features/hero/components/hero-section.tsx
@@ -91,7 +91,9 @@ export function HeroSection() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: "easeOut", delay: 0.2 }}
       >
-        {t("subheadline")}
+        {t("subheadline1")}
+        <br />
+        {t("subheadline2")}
       </motion.p>
 
       <motion.div

--- a/features/hero/components/nav-bar.tsx
+++ b/features/hero/components/nav-bar.tsx
@@ -1,26 +1,50 @@
 "use client";
 
-import { Link } from "@/i18n/navigation";
+import { Link, usePathname } from "@/i18n/navigation";
 import { LocaleSwitcher } from "@/features/dashboard/components/locale-switcher";
 import { ModeToggle } from "@/features/dashboard/components/mode-toggle";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 
 export function NavBar() {
   const t = useTranslations("hero.nav");
+  const pathname = usePathname();
+  const locale = useLocale();
+  const isHeroPage = pathname === "/";
 
   return (
     <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-primary/30">
       <div className="px-4 h-16 flex items-center relative">
         {/* Logo */}
-        <span className="text-xl font-bold text-primary tracking-wider px-2">
-          AIPM
-        </span>
+        {isHeroPage ? (
+          <span
+            className="text-xl font-bold text-primary tracking-wider px-2 cursor-pointer"
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          >
+            PortfolioX
+          </span>
+        ) : (
+          <a
+            href={`/${locale}`}
+            className="text-xl font-bold text-primary tracking-wider px-2"
+          >
+            PortfolioX
+          </a>
+        )}
 
         {/* Nav Links (desktop only) — truly centered */}
         <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 items-center gap-8 text-sm text-muted-foreground">
-          <a href="#features" className="hover:text-primary transition-colors">
-            {t("features")}
-          </a>
+          {isHeroPage ? (
+            <a href="#features" className="hover:text-primary transition-colors">
+              {t("features")}
+            </a>
+          ) : (
+            <a
+              href={`/${locale}#features`}
+              className="hover:text-primary transition-colors"
+            >
+              {t("features")}
+            </a>
+          )}
           <a
             href="https://cyoukakitsu-portfolio.pages.dev/"
             target="_blank"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,41 @@
 {
+  "settings": {
+    "title": "Settings",
+    "dropdown": {
+      "settings": "Settings",
+      "signOut": "Sign Out"
+    },
+    "portfolioData": {
+      "title": "Portfolio Data",
+      "description": "Delete all data in your current portfolio. This action cannot be undone.",
+      "deleteButton": "Delete All Data",
+      "confirmTitle": "Are you sure?",
+      "confirmDescription": "All assets and transaction history in your portfolio will be permanently deleted. This action cannot be undone.",
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "confirm": "Delete"
+    },
+    "password": {
+      "title": "Change Password",
+      "currentPassword": "Current password",
+      "newPassword": "New password (min. 6 characters)",
+      "confirmPassword": "Confirm new password",
+      "changing": "Changing...",
+      "submit": "Change Password"
+    },
+    "toast": {
+      "deleteSuccess": "All portfolio data has been deleted.",
+      "deleteFailed": "Failed to delete. Please try again.",
+      "currentPasswordRequired": "Please enter your current password.",
+      "passwordTooShort": "Password must be at least 6 characters.",
+      "passwordMismatch": "Passwords do not match.",
+      "passwordChanged": "Password changed successfully.",
+      "passwordChangeFailed": "Failed to change password.",
+      "invalidCurrentPassword": "Current password is incorrect.",
+      "userNotFound": "Could not retrieve user information.",
+      "updateFailed": "Failed to update password. Please try again."
+    }
+  },
   "nav": {
     "assets": "Your Assets",
     "personalPortfolio": "Personal Portfolio",
@@ -6,7 +43,7 @@
     "marketOverview": "Market Overview",
     "crypto": "Crypto",
     "aiAnalysis": "AI Analysis",
-    "multiAgentAnalysis": "Multi-Agent Analysis"
+    "multiAgentAnalysis": "AI Investors"
   },
   "auth": {
     "signIn": {
@@ -223,7 +260,8 @@
     "headlineLine1": "Your Portfolio,",
     "headlinePrefix": "Analyzed by",
     "headlineAccent": "Legends",
-    "subheadline": "Track stocks & crypto. Get AI insights from 5 legendary investors.",
+    "subheadline1": "Track stocks & crypto.",
+    "subheadline2": "Get AI insights from 5 legendary investors.",
     "signIn": "Sign In",
     "signUp": "Get Started",
     "features": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,4 +1,41 @@
 {
+  "settings": {
+    "title": "設定",
+    "dropdown": {
+      "settings": "設定",
+      "signOut": "ログアウト"
+    },
+    "portfolioData": {
+      "title": "ポートフォリオデータ",
+      "description": "現在のポートフォリオにある全てのデータを削除します。この操作は取り消せません。",
+      "deleteButton": "全データを削除",
+      "confirmTitle": "本当に削除しますか？",
+      "confirmDescription": "ポートフォリオ内の全ての資産と取引履歴が完全に削除されます。この操作は取り消せません。",
+      "cancel": "キャンセル",
+      "deleting": "削除中...",
+      "confirm": "削除する"
+    },
+    "password": {
+      "title": "パスワード変更",
+      "currentPassword": "現在のパスワード",
+      "newPassword": "新しいパスワード（6文字以上）",
+      "confirmPassword": "新しいパスワード（確認）",
+      "changing": "変更中...",
+      "submit": "パスワードを変更"
+    },
+    "toast": {
+      "deleteSuccess": "ポートフォリオデータをすべて削除しました。",
+      "deleteFailed": "削除に失敗しました。もう一度お試しください。",
+      "currentPasswordRequired": "現在のパスワードを入力してください。",
+      "passwordTooShort": "パスワードは6文字以上で設定してください。",
+      "passwordMismatch": "パスワードが一致しません。",
+      "passwordChanged": "パスワードを変更しました。",
+      "passwordChangeFailed": "パスワードの変更に失敗しました。",
+      "invalidCurrentPassword": "現在のパスワードが正しくありません。",
+      "userNotFound": "ユーザー情報を取得できませんでした。",
+      "updateFailed": "パスワードの更新に失敗しました。もう一度お試しください。"
+    }
+  },
   "nav": {
     "assets": "アセット",
     "personalPortfolio": "ポートフォリオ",
@@ -6,7 +43,7 @@
     "marketOverview": "マーケット概況",
     "crypto": "暗号資産",
     "aiAnalysis": "AI分析",
-    "multiAgentAnalysis": "マルチエージェント分析"
+    "multiAgentAnalysis": "AI 投資家"
   },
   "auth": {
     "signIn": {
@@ -219,7 +256,8 @@
     "headlineLine1": "あなたのポートフォリオを、",
     "headlinePrefix": "伝説が",
     "headlineAccent": "分析する",
-    "subheadline": "株式と暗号資産をトラッキング。5人の伝説的投資家AIがポートフォリオを分析。",
+    "subheadline1": "株式と暗号資産を追跡",
+    "subheadline2": "5人の伝説的投資家AIがポートフォリオを分析",
     "signIn": "サインイン",
     "signUp": "新規登録",
     "features": {


### PR DESCRIPTION
## 概要

プロジェクト名を「AIPM」から「PortfolioX」に変更し、NavBar の動作改善、設定モーダルのセキュリティ強化、および設定関連テキストの全面的な i18n 対応を行いました。

## 変更内容

### プロジェクト名変更
- `NavBar` のロゴを「AIPM」→「PortfolioX」に変更
- `app/layout.tsx` のページタイトルを「AI Portfolio Manager」→「PortfolioX」に変更

### NavBar の改善
- 認証ページ（サインイン・サインアップ）に Hero ページと同じ `NavBar` を適用
- ロゴクリック時の動作を改善
  - Hero ページ内では先頭へスムーズスクロール
  - 他ページからはトップページへ遷移
- `Features` リンクの動作を改善
  - Hero ページ内では `#features` アンカーへスクロール
  - 認証ページからは `/{locale}#features` へ正しく遷移（next-intl の hash fragment バグを `useLocale` + `<a>` タグで回避）
- `Multi-Agent Analysis` を `AI Investors` に変更（`en.json` / `ja.json`）

### Hero セクション
- サブヘッドライン「株式と暗号資産をトラッキング。5人の伝説的投資家AIがポートフォリオを分析。」を2行に分割して表示
  - `subheadline` → `subheadline1` / `subheadline2` に分割（英語・日本語両対応）

### 設定モーダルのセキュリティ強化
- パスワード変更フォームに「現在のパスワード」入力欄を追加
- Server Action でパスワード変更前に `signInWithPassword` で現在のパスワードを検証するよう変更
- エラーメッセージをハードコードからエラーコード返却方式に変更し、クライアント側で翻訳

### 設定 UI の国際化（i18n）
- `settings-modal.tsx` の全テキストを `useTranslations("settings")` に対応
- `user-avatar.tsx` のドロップダウン「設定」「ログアウト」を `useTranslations("settings.dropdown")` に対応
- `en.json` / `ja.json` に `settings` namespace を新規追加（UI テキスト・トーストメッセージ・エラーコード訳すべて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added current password verification when changing account password
  * Implemented multi-language support (English and Japanese) throughout settings and authentication flows

* **Updates**
  * Rebranded app title to "PortfolioX"
  * Relabeled feature from "Multi-Agent Analysis" to "AI Investors"
  * Enhanced navigation experience with improved routing behavior
  * Updated hero section messaging layout for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->