### PR TITLE
fix: 未ログインユーザーが hero ページにアクセスできない問題を修正 

### DIFF
--- a/app/api/assets/ai-summary/route.ts
+++ b/app/api/assets/ai-summary/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: Request) {
     .join("\n");
 
   const result = streamText({
-    model: openrouter("qwen/qwen3.6-plus:free"),
+    model: openrouter("openrouter/free"),
     tools: {
       tavilySearch: tavilySearch({ maxResults: 2 }),
     },

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -46,8 +46,11 @@ export async function updateSession(request: NextRequest) {
   // 未登录 且 访问的不是公开页面 → 重定向到登录页
   const pathname = request.nextUrl.pathname;
   const locale = pathname.split("/")[1] || "ja";
+  // ロケールルートパス（/ja, /ja/, /en, /en/）はheroページなので公開
+  const isLocaleRoot = /^\/[a-z]{2}\/?$/.test(pathname);
   if (
     !user &&
+    !isLocaleRoot &&
     !pathname.includes("/sign-in") &&
     !pathname.includes("/sign-up") &&
     !pathname.startsWith("/auth/")


### PR DESCRIPTION
## 概要
- Vercel にデプロイした状態で、未ログインユーザーがサイトを開くと hero  ページではなくログインページが表示される。

## 原因
      
  lib/supabase/middleware.ts の認証ガードは、未ログインユーザーを/sign-in・/sign-up・/auth/ 以外のすべてのページからブロックする実装になっていた。
しかし hero ページ（/ja/・/en/）はこのホワイトリストに含まれていなかったため、以下のリダイレクトループが発生していた。
                                                                        
/ → (next-intl) → /ja/ → (middleware: 未ログイン) → /ja/sign-in
                                                                        
  ロゴクリック時も同様に href="/" → /ja/ → /ja/sign-in に戻るループとなっていた。                                            
                                                                              
## 修正内容
          
  lib/supabase/middleware.ts に、ロケールルートパス（/ja・/ja/・/en・/en
  /）を公開ページとして判定する条件を追加した。                         


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication flow to prevent unnecessary sign-in redirects when accessing certain locale-specific pages.
  * Updated AI-powered content summarization to use an alternative processing model for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->