### PR TITLE
fix: AI分析画面・Assetsページの国際化漏れを修正

### DIFF
--- a/features/ai/components/agent-card.tsx
+++ b/features/ai/components/agent-card.tsx
@@ -4,14 +4,15 @@ import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { AgentResult } from "@/features/ai/types";
-import { PERSONA_META, VERDICT_LABEL, VERDICT_STYLE } from "@/features/ai/lib/constants";
+import { PERSONA_META, VERDICT_STYLE } from "@/features/ai/lib/constants";
 
 type AgentCardProps = AgentResult;
 
 export function AgentCard({ persona, score, verdict, points, buyRange }: AgentCardProps) {
   const t = useTranslations("pages.ai");
+  const tAnalyst = useTranslations("aiAnalyst");
+  const tVerdict = useTranslations("verdict");
   const meta = PERSONA_META[persona];
-  const verdictLabel = VERDICT_LABEL[verdict];
 
   return (
     <Card>
@@ -22,11 +23,11 @@ export function AgentCard({ persona, score, verdict, points, buyRange }: AgentCa
             <span className="text-2xl">{meta.emoji}</span>
             <div>
               <p className="text-sm font-medium">{meta.name}</p>
-              <p className="text-xs text-muted-foreground">{meta.role}</p>
+              <p className="text-xs text-muted-foreground">{tAnalyst(`${persona}.role`)}</p>
             </div>
           </div>
           {/* 右侧：verdict badge */}
-          <Badge className={VERDICT_STYLE[verdict]}>{verdictLabel}</Badge>
+          <Badge className={VERDICT_STYLE[verdict]}>{tVerdict(verdict)}</Badge>
         </div>
       </CardHeader>
 
@@ -34,7 +35,7 @@ export function AgentCard({ persona, score, verdict, points, buyRange }: AgentCa
         {/* 分数进度条 */}
         <div className="mb-4 space-y-1.5">
           <div className="flex justify-between text-xs text-muted-foreground">
-            <span>Score</span>
+            <span>{tVerdict("score")}</span>
             <span className="font-medium text-foreground">{score} / 100</span>
           </div>
           <div className="h-1.5 rounded-full bg-muted overflow-hidden">

--- a/features/ai/components/agent-detail-modal.tsx
+++ b/features/ai/components/agent-detail-modal.tsx
@@ -57,7 +57,7 @@ export function AgentDetailModal({ modalOpen, onClose }: AgentDetailModalProps) 
                     {activePersona.name}
                   </DialogTitle>
                   <p className="text-sm text-muted-foreground mt-0.5">
-                    {activePersona.role}
+                    {t(`${modalOpen}.role`)}
                   </p>
                   {/* 分析风格标签 */}
                   <div className="flex flex-wrap gap-1.5 mt-2">

--- a/features/ai/components/coordinator-card.tsx
+++ b/features/ai/components/coordinator-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { CoordinatorResult } from "@/features/ai/types";
-import { VERDICT_LABEL, VERDICT_STYLE } from "@/features/ai/lib/constants";
+import { VERDICT_STYLE } from "@/features/ai/lib/constants";
 
 export function CoordinatorCard({
   verdict,
@@ -13,6 +13,7 @@ export function CoordinatorCard({
   buyRange,
 }: CoordinatorResult) {
   const t = useTranslations("pages.ai");
+  const tVerdict = useTranslations("verdict");
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -20,14 +21,14 @@ export function CoordinatorCard({
           <div className="flex items-center gap-2">
             <span className="text-2xl">⚖️</span>
             <div>
-              <p className="text-sm font-medium">Coordinator</p>
-              <p className="text-xs text-muted-foreground">Final Verdict</p>
+              <p className="text-sm font-medium">{t("coordinatorName")}</p>
+              <p className="text-xs text-muted-foreground">{t("coordinatorRole")}</p>
             </div>
           </div>
           {/* verdict 标签 + score 进度条 */}
           <div className="flex items-center gap-2 flex-wrap">
-            <Badge className={`text-sm px-3 py-1 ${VERDICT_STYLE[verdict]}`}>{VERDICT_LABEL[verdict]}</Badge>
-            <span className="text-sm text-muted-foreground">Score</span>
+            <Badge className={`text-sm px-3 py-1 ${VERDICT_STYLE[verdict]}`}>{tVerdict(verdict)}</Badge>
+            <span className="text-sm text-muted-foreground">{tVerdict("score")}</span>
             <div className="w-20 sm:w-24 h-2 rounded-full bg-muted overflow-hidden">
               <div
                 className="h-full bg-primary rounded-full"

--- a/features/assets/components/daily-analysis.tsx
+++ b/features/assets/components/daily-analysis.tsx
@@ -6,6 +6,7 @@
 import type { Asset } from "@/types/global";
 import type { NewsArticle } from "@/app/api/assets/news/route";
 import { RefreshCw, ExternalLink, Newspaper } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
@@ -84,6 +85,7 @@ function LoadingSkeleton() {
 // 主组件
 // ==============================
 export function DailyAnalysis({ assets }: Props) {
+  const t = useTranslations("dailyAnalysis");
   const { symbols, results, isFetching, hasNews, lastUpdated, refetch } =
     useDailyAnalysis({ assets });
 
@@ -93,8 +95,8 @@ export function DailyAnalysis({ assets }: Props) {
       <div className="flex items-center justify-between px-4 py-2 border-b border-border/40">
         <span className="text-[11px] text-muted-foreground">
           {lastUpdated
-            ? `更新: ${lastUpdated.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })}`
-            : "持ち株の最新ニュースを取得中…"}
+            ? `${t("updating")}${lastUpdated.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}`
+            : t("loading")}
         </span>
         <Button
           size="icon"
@@ -114,12 +116,12 @@ export function DailyAnalysis({ assets }: Props) {
         ) : symbols.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 gap-2 text-muted-foreground">
             <Newspaper className="h-6 w-6 opacity-30" />
-            <p className="text-xs">資産を追加するとニュースが表示されます</p>
+            <p className="text-xs">{t("emptyState")}</p>
           </div>
         ) : !hasNews ? (
           <div className="flex flex-col items-center justify-center h-40 gap-2 text-muted-foreground">
             <Newspaper className="h-6 w-6 opacity-30" />
-            <p className="text-xs">ニュースが見つかりませんでした</p>
+            <p className="text-xs">{t("noNews")}</p>
           </div>
         ) : (
           results.map((item) => <SymbolSection key={item.symbol} item={item} />)

--- a/features/assets/components/portfolio-ai-summary.tsx
+++ b/features/assets/components/portfolio-ai-summary.tsx
@@ -63,10 +63,8 @@ export function PortfolioAISummary({ assets }: Props) {
         {/* 加载中：骨架屏动画；加载完成：渲染 Markdown */}
         <div className="min-h-50 max-h-[60vh] overflow-y-auto pr-1">
           {loading ? (
-            <div className="space-y-2.5 animate-pulse pt-2">
-              {[75, 55, 85, 45, 65, 70, 50].map((w, i) => (
-                <div key={i} className="h-3 rounded bg-muted" style={{ width: `${w}%` }} />
-              ))}
+            <div className="flex items-center justify-center h-full min-h-50 text-sm text-muted-foreground">
+              {t("analyzing")}
             </div>
           ) : text ? (
             <div className="prose prose-sm dark:prose-invert max-w-none text-[13px] leading-relaxed">

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,7 +93,7 @@
     "signUp": "Sign Up"
   },
   "aiSummary": {
-    "analyzing": "AI analyzing...",
+    "analyzing": "AI is analyzing, please wait...",
     "reanalyze": "Re-analyze",
     "title": "AI Portfolio Analysis",
     "description": "Comprehensive analysis of technical, fundamental & industry trends",
@@ -108,7 +108,16 @@
     "finalVerdict": "Final Verdict"
   },
   "verdict": {
-    "score": "Score"
+    "score": "Score",
+    "buy": "Buy",
+    "hold": "Hold",
+    "sell": "Sell"
+  },
+  "dailyAnalysis": {
+    "updating": "Updated: ",
+    "loading": "Fetching latest news for your holdings…",
+    "emptyState": "Add assets to see news",
+    "noNews": "No news found"
   },
   "pages": {
     "assets": {
@@ -154,7 +163,9 @@
       "fetchError": "Analysis failed. Please try again.",
       "buyRange": "Buy Range",
       "targetPriceRange": "Target Price Range",
-      "combinedRangeNote": "Combined buy range from both analysts"
+      "combinedRangeNote": "Combined buy range from both analysts",
+      "coordinatorName": "Coordinator",
+      "coordinatorRole": "Final Verdict"
     }
   },
   "aiAnalyst": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -93,7 +93,7 @@
     "signUp": "新規登録"
   },
   "aiSummary": {
-    "analyzing": "AI分析中...",
+    "analyzing": "AI分析中、しばらくお待ちください...",
     "reanalyze": "再分析",
     "title": "AIポートフォリオ分析",
     "description": "テクニカル・ファンダメンタルズ・業界動向を総合分析",
@@ -108,7 +108,16 @@
     "finalVerdict": "最終判定"
   },
   "verdict": {
-    "score": "スコア"
+    "score": "スコア",
+    "buy": "買い",
+    "hold": "保有",
+    "sell": "売り"
+  },
+  "dailyAnalysis": {
+    "updating": "更新: ",
+    "loading": "持ち株の最新ニュースを取得中…",
+    "emptyState": "資産を追加するとニュースが表示されます",
+    "noNews": "ニュースが見つかりませんでした"
   },
   "pages": {
     "assets": {
@@ -154,7 +163,9 @@
       "fetchError": "分析に失敗しました。もう一度お試しください。",
       "buyRange": "買入レンジ",
       "targetPriceRange": "目標価格帯",
-      "combinedRangeNote": "両アナリストの買入レンジの統合"
+      "combinedRangeNote": "両アナリストの買入レンジの統合",
+      "coordinatorName": "コーディネーター",
+      "coordinatorRole": "最終判定"
     }
   },
   "aiAnalyst": {


### PR DESCRIPTION
## 概要

- AI分析画面（`/dashboard/ai`）とAssetsページのウィジェットにおいて、英語・日本語がハードコードされていた箇所をすべて `next-intl` による国際化対応に統一

## 主な変更内容

- **`agent-card.tsx`** — アナリスト役職・verdict ラベル（Buy/Hold/Sell）・Score を i18n 化
- **`coordinator-card.tsx`** — "Coordinator"・"Final Verdict"・"Score"・verdict ラベルを i18n 化
- **`agent-detail-modal.tsx`** — アナリスト役職を i18n 化
- **`daily-analysis.tsx`** — 日本語ハードコード文字列（更新時刻・ローディング・空状態）を i18n 化
- **`portfolio-ai-summary.tsx`** — ローディング表示をスケルトンからテキスト（`aiSummary.analyzing`）に変更
- **`messages/en.json` / `messages/ja.json`** — `verdict`・`dailyAnalysis`・`pages.ai` に不足キーを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support (English and Japanese) for AI analysis features including verdict labels, analyst roles, and status indicators
  * Improved localization for daily analysis messages and portfolio AI summary status displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->