### PR TITLE
feat: パスワードリセット機能を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ DEEPSEEK_API_KEY=dsk_your_deepseek_api_key_here
 
 # Tavily（用于 AI 功能的网络搜索与新闻）
 TAVILY_API_KEY=tvly-your_tavily_api_key_here
+
+# サイトURL（パスワードリセットメールのリダイレクト先に使用）
+# 開発環境: http://localhost:3000
+# 本番環境: https://your-domain.com
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/app/[locale]/(auth)/reset-password/page.tsx
+++ b/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,0 +1,5 @@
+import ResetPasswordForm from "@/features/auth/components/reset-password-form";
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />;
+}

--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { motion, AnimatePresence } from "motion/react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import {
+  forgotPasswordSchema,
+  ForgotPasswordFormValues,
+} from "@/features/auth/schemas/forgot-password";
+import { resetPasswordEmail } from "@/features/auth/server/auth";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const fieldVariants = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: "easeOut" as const },
+  },
+};
+
+interface ForgotPasswordFormProps {
+  onBack: () => void;
+}
+
+const ForgotPasswordForm = ({ onBack }: ForgotPasswordFormProps) => {
+  const t = useTranslations("auth.forgotPassword");
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = async (data: ForgotPasswordFormValues) => {
+    const result = await resetPasswordEmail(data.email);
+    if (result?.error) {
+      toast.error(t("errorToast"));
+    } else {
+      toast.success(t("successToast"));
+      onBack();
+    }
+  };
+
+  return (
+    <motion.div
+      key="forgot-password"
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -20 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold text-card-foreground tracking-tight">
+          {t("title")}
+        </h2>
+        <p className="text-sm text-muted-foreground mt-1">{t("subtitle")}</p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <motion.div
+          variants={{
+            hidden: { opacity: 0 },
+            show: { opacity: 1, transition: { staggerChildren: 0.08 } },
+          }}
+          initial="hidden"
+          animate="show"
+          className="space-y-5"
+        >
+          <motion.div variants={fieldVariants} className="space-y-1.5">
+            <label
+              htmlFor="forgot-email"
+              className="block text-sm font-medium text-foreground"
+            >
+              {t("email")}
+            </label>
+            <Input
+              {...register("email")}
+              id="forgot-email"
+              type="email"
+              placeholder="fujimoto@example.com"
+            />
+            <AnimatePresence>
+              {errors.email && (
+                <motion.p
+                  key="email-error"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2 }}
+                  className="text-xs text-destructive overflow-hidden"
+                >
+                  {errors.email.message}
+                </motion.p>
+              )}
+            </AnimatePresence>
+          </motion.div>
+
+          <motion.div variants={fieldVariants} className="space-y-3 pt-1">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full cursor-pointer"
+            >
+              {isSubmitting ? t("sending") : t("submit")}
+            </Button>
+          </motion.div>
+
+          <motion.p
+            variants={fieldVariants}
+            className="text-center text-sm"
+          >
+            <button
+              type="button"
+              onClick={onBack}
+              className="text-primary hover:text-primary/80 transition-colors cursor-pointer"
+            >
+              {t("backToSignIn")}
+            </button>
+          </motion.p>
+        </motion.div>
+      </form>
+    </motion.div>
+  );
+};
+
+export default ForgotPasswordForm;

--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -39,13 +39,9 @@ const ForgotPasswordForm = ({ onBack }: ForgotPasswordFormProps) => {
   });
 
   const onSubmit = async (data: ForgotPasswordFormValues) => {
-    const result = await resetPasswordEmail(data.email);
-    if (result?.error) {
-      toast.error(t("errorToast"));
-    } else {
-      toast.success(t("successToast"));
-      onBack();
-    }
+    await resetPasswordEmail(data.email);
+    toast.success(t("successToast"));
+    onBack();
   };
 
   return (

--- a/features/auth/components/reset-password-form.tsx
+++ b/features/auth/components/reset-password-form.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { motion, AnimatePresence } from "motion/react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import {
+  resetPasswordSchema,
+  ResetPasswordFormValues,
+} from "@/features/auth/schemas/reset-password";
+import { updatePassword } from "@/features/auth/server/auth";
+import { useRouter } from "@/i18n/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const fieldVariants = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: "easeOut" as const },
+  },
+};
+
+const ResetPasswordForm = () => {
+  const t = useTranslations("auth.resetPassword");
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  const onSubmit = async (data: ResetPasswordFormValues) => {
+    const result = await updatePassword(data.password);
+    if (result?.error) {
+      toast.error(t("errorToast"));
+    } else {
+      toast.success(t("successToast"));
+      router.push("/sign-in");
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      className="w-full"
+    >
+      <div className="rounded-xl border border-border bg-card shadow-lg overflow-hidden">
+        <div
+          className="h-px w-full"
+          style={{
+            background:
+              "linear-gradient(to right, transparent, var(--color-primary), transparent)",
+          }}
+        />
+
+        <div className="px-7 py-8">
+          <div className="mb-8">
+            <h2 className="text-xl font-semibold text-card-foreground tracking-tight">
+              {t("title")}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {t("subtitle")}
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <motion.div
+              variants={{
+                hidden: { opacity: 0 },
+                show: { opacity: 1, transition: { staggerChildren: 0.08 } },
+              }}
+              initial="hidden"
+              animate="show"
+              className="space-y-5"
+            >
+              <motion.div variants={fieldVariants} className="space-y-1.5">
+                <label
+                  htmlFor="new-password"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  {t("newPassword")}
+                </label>
+                <Input
+                  {...register("password")}
+                  id="new-password"
+                  type="password"
+                />
+                <AnimatePresence>
+                  {errors.password && (
+                    <motion.p
+                      key="password-error"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="text-xs text-destructive overflow-hidden"
+                    >
+                      {errors.password.message}
+                    </motion.p>
+                  )}
+                </AnimatePresence>
+              </motion.div>
+
+              <motion.div variants={fieldVariants} className="space-y-1.5">
+                <label
+                  htmlFor="confirm-password"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  {t("confirmPassword")}
+                </label>
+                <Input
+                  {...register("confirmPassword")}
+                  id="confirm-password"
+                  type="password"
+                />
+                <AnimatePresence>
+                  {errors.confirmPassword && (
+                    <motion.p
+                      key="confirm-error"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: 0.2 }}
+                      className="text-xs text-destructive overflow-hidden"
+                    >
+                      {errors.confirmPassword.message}
+                    </motion.p>
+                  )}
+                </AnimatePresence>
+              </motion.div>
+
+              <motion.div variants={fieldVariants} className="pt-1">
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full cursor-pointer"
+                >
+                  {isSubmitting ? t("updating") : t("submit")}
+                </Button>
+              </motion.div>
+            </motion.div>
+          </form>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default ResetPasswordForm;

--- a/features/auth/components/sign-in-form.tsx
+++ b/features/auth/components/sign-in-form.tsx
@@ -7,6 +7,7 @@
 //   1. 客户端：Zod 实时校验，给出即时错误提示
 //   2. 服务端 Server Action 中：二次校验，防止绕过前端直接请求
 
+import { useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { motion, AnimatePresence } from "motion/react";
@@ -14,6 +15,7 @@ import { useTranslations } from "next-intl";
 
 import { signInSchema, SignInFormValues } from "@/features/auth/schemas/sign-in";
 import GoogleButton from "./google-button";
+import ForgotPasswordForm from "./forgot-password-form";
 import { signIn } from "@/features/auth/server/auth";
 import { Link } from "@/i18n/navigation";
 
@@ -32,6 +34,7 @@ const fieldVariants = {
 
 const SignInForm = () => {
   const t = useTranslations("auth.signIn");
+  const [view, setView] = useState<"signIn" | "forgotPassword">("signIn");
   const {
     register,
     handleSubmit,
@@ -67,120 +70,138 @@ const SignInForm = () => {
         />
 
         <div className="px-7 py-8">
-          {/* Header */}
-          <div className="mb-8">
-            <h2 className="text-xl font-semibold text-card-foreground tracking-tight">
-              {t("title")}
-            </h2>
-            <p className="text-sm text-muted-foreground mt-1">
-              {t("subtitle")}
-            </p>
-          </div>
-
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <motion.div
-              variants={{
-                hidden: { opacity: 0 },
-                show: { opacity: 1, transition: { staggerChildren: 0.08 } },
-              }}
-              initial="hidden"
-              animate="show"
-              className="space-y-5"
-            >
-              {/* Email */}
-              <motion.div variants={fieldVariants} className="space-y-1.5">
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-foreground"
-                >
-                  {t("email")}
-                </label>
-                <Input
-                  {...register("email")}
-                  id="email"
-                  type="email"
-                  placeholder="fujimoto@example.com"
-                />
-                <AnimatePresence>
-                  {errors.email && (
-                    <motion.p
-                      key="email-error"
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: "auto" }}
-                      exit={{ opacity: 0, height: 0 }}
-                      transition={{ duration: 0.2 }}
-                      className="text-xs text-destructive overflow-hidden"
-                    >
-                      {errors.email.message}
-                    </motion.p>
-                  )}
-                </AnimatePresence>
-              </motion.div>
-
-              {/* Password */}
-              <motion.div variants={fieldVariants} className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="password"
-                    className="block text-sm font-medium text-foreground"
-                  >
-                    {t("password")}
-                  </label>
-                  <a
-                    href="#"
-                    className="text-xs text-primary hover:text-primary/80 transition-colors cursor-pointer"
-                  >
-                    {t("forgotPassword")}
-                  </a>
-                </div>
-                <Input
-                  {...register("password")}
-                  id="password"
-                  type="password"
-                />
-                <AnimatePresence>
-                  {errors.password && (
-                    <motion.p
-                      key="password-error"
-                      initial={{ opacity: 0, height: 0 }}
-                      animate={{ opacity: 1, height: "auto" }}
-                      exit={{ opacity: 0, height: 0 }}
-                      transition={{ duration: 0.2 }}
-                      className="text-xs text-destructive overflow-hidden"
-                    >
-                      {errors.password.message}
-                    </motion.p>
-                  )}
-                </AnimatePresence>
-              </motion.div>
-
-              {/* Buttons */}
-              <motion.div variants={fieldVariants} className="space-y-3 pt-1">
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="w-full cursor-pointer"
-                >
-                  {isSubmitting ? t("signingIn") : t("submit")}
-                </Button>
-                <GoogleButton />
-              </motion.div>
-
-              {/* Footer link */}
-              <motion.p
-                variants={fieldVariants}
-                className="text-center text-sm text-muted-foreground"
+          <AnimatePresence mode="wait">
+            {view === "forgotPassword" ? (
+              <ForgotPasswordForm
+                key="forgot"
+                onBack={() => setView("signIn")}
+              />
+            ) : (
+              <motion.div
+                key="sign-in"
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: 20 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
               >
-                {t("noAccount")}{" "}
-                <Link
-                  href="/sign-up"
-                  className="text-primary hover:text-primary/80 transition-colors"
-                >
-                  {t("signUp")}
-                </Link>
-              </motion.p>
-            </motion.div>
-          </form>
+                {/* Header */}
+                <div className="mb-8">
+                  <h2 className="text-xl font-semibold text-card-foreground tracking-tight">
+                    {t("title")}
+                  </h2>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {t("subtitle")}
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmit(onSubmit)}>
+                  <motion.div
+                    variants={{
+                      hidden: { opacity: 0 },
+                      show: { opacity: 1, transition: { staggerChildren: 0.08 } },
+                    }}
+                    initial="hidden"
+                    animate="show"
+                    className="space-y-5"
+                  >
+                    {/* Email */}
+                    <motion.div variants={fieldVariants} className="space-y-1.5">
+                      <label
+                        htmlFor="email"
+                        className="block text-sm font-medium text-foreground"
+                      >
+                        {t("email")}
+                      </label>
+                      <Input
+                        {...register("email")}
+                        id="email"
+                        type="email"
+                        placeholder="fujimoto@example.com"
+                      />
+                      <AnimatePresence>
+                        {errors.email && (
+                          <motion.p
+                            key="email-error"
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: "auto" }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.2 }}
+                            className="text-xs text-destructive overflow-hidden"
+                          >
+                            {errors.email.message}
+                          </motion.p>
+                        )}
+                      </AnimatePresence>
+                    </motion.div>
+
+                    {/* Password */}
+                    <motion.div variants={fieldVariants} className="space-y-1.5">
+                      <div className="flex items-center justify-between">
+                        <label
+                          htmlFor="password"
+                          className="block text-sm font-medium text-foreground"
+                        >
+                          {t("password")}
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => setView("forgotPassword")}
+                          className="text-xs text-primary hover:text-primary/80 transition-colors cursor-pointer"
+                        >
+                          {t("forgotPassword")}
+                        </button>
+                      </div>
+                      <Input
+                        {...register("password")}
+                        id="password"
+                        type="password"
+                      />
+                      <AnimatePresence>
+                        {errors.password && (
+                          <motion.p
+                            key="password-error"
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: "auto" }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.2 }}
+                            className="text-xs text-destructive overflow-hidden"
+                          >
+                            {errors.password.message}
+                          </motion.p>
+                        )}
+                      </AnimatePresence>
+                    </motion.div>
+
+                    {/* Buttons */}
+                    <motion.div variants={fieldVariants} className="space-y-3 pt-1">
+                      <Button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="w-full cursor-pointer"
+                      >
+                        {isSubmitting ? t("signingIn") : t("submit")}
+                      </Button>
+                      <GoogleButton />
+                    </motion.div>
+
+                    {/* Footer link */}
+                    <motion.p
+                      variants={fieldVariants}
+                      className="text-center text-sm text-muted-foreground"
+                    >
+                      {t("noAccount")}{" "}
+                      <Link
+                        href="/sign-up"
+                        className="text-primary hover:text-primary/80 transition-colors"
+                      >
+                        {t("signUp")}
+                      </Link>
+                    </motion.p>
+                  </motion.div>
+                </form>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </div>
     </motion.div>

--- a/features/auth/schemas/forgot-password.ts
+++ b/features/auth/schemas/forgot-password.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const forgotPasswordSchema = z.object({
+  email: z.email("Please enter a valid email address"),
+});
+
+export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;

--- a/features/auth/schemas/reset-password.ts
+++ b/features/auth/schemas/reset-password.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;

--- a/features/auth/server/auth.ts
+++ b/features/auth/server/auth.ts
@@ -5,6 +5,8 @@
 
 import { signInSchema } from "@/features/auth/schemas/sign-in";
 import { signUpSchema } from "@/features/auth/schemas/sign-up";
+import { forgotPasswordSchema } from "@/features/auth/schemas/forgot-password";
+import { resetPasswordSchema } from "@/features/auth/schemas/reset-password";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 
@@ -94,5 +96,31 @@ export async function changePassword(currentPassword: string, newPassword: strin
   if (error) {
     return { errorCode: "updateFailed" };
   }
+  return { success: true };
+}
+
+export async function resetPasswordEmail(email: unknown) {
+  const result = forgotPasswordSchema.safeParse({ email });
+  if (!result.success) return { error: "Invalid email" };
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.resetPasswordForEmail(result.data.email, {
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/ja/reset-password`,
+  });
+
+  if (error) return { error: "Failed to send reset email." };
+  return { success: true };
+}
+
+export async function updatePassword(newPassword: unknown) {
+  const result = resetPasswordSchema.safeParse({
+    password: newPassword,
+    confirmPassword: newPassword,
+  });
+  if (!result.success) return { error: "Password too short" };
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.updateUser({ password: result.data.password });
+  if (error) return { error: "Update failed." };
   return { success: true };
 }

--- a/features/auth/server/auth.ts
+++ b/features/auth/server/auth.ts
@@ -3,10 +3,10 @@
 // Server Actions：处理注册 / 登录逻辑
 //参考https://supabase.com/docs/guides/getting-started/tutorials/with-nextjs
 
+import { z } from "zod";
 import { signInSchema } from "@/features/auth/schemas/sign-in";
 import { signUpSchema } from "@/features/auth/schemas/sign-up";
 import { forgotPasswordSchema } from "@/features/auth/schemas/forgot-password";
-import { resetPasswordSchema } from "@/features/auth/schemas/reset-password";
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 
@@ -113,14 +113,11 @@ export async function resetPasswordEmail(email: unknown) {
 }
 
 export async function updatePassword(newPassword: unknown) {
-  const result = resetPasswordSchema.safeParse({
-    password: newPassword,
-    confirmPassword: newPassword,
-  });
+  const result = z.string().min(6, "Password must be at least 6 characters").safeParse(newPassword);
   if (!result.success) return { error: "Password too short" };
 
   const supabase = await createClient();
-  const { error } = await supabase.auth.updateUser({ password: result.data.password });
+  const { error } = await supabase.auth.updateUser({ password: result.data });
   if (error) return { error: "Update failed." };
   return { success: true };
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -72,6 +72,26 @@
       "hasAccount": "Already have an account?",
       "signIn": "Sign in"
     },
+    "forgotPassword": {
+      "title": "Reset Password",
+      "subtitle": "Enter your registered email address",
+      "email": "Email Address",
+      "submit": "Send Reset Email",
+      "sending": "Sending…",
+      "successToast": "Email sent. Please check your inbox.",
+      "errorToast": "Failed to send email. Please try again.",
+      "backToSignIn": "Back to Sign In"
+    },
+    "resetPassword": {
+      "title": "Set New Password",
+      "subtitle": "Enter your new password",
+      "newPassword": "New Password",
+      "confirmPassword": "Confirm Password",
+      "submit": "Update Password",
+      "updating": "Updating…",
+      "successToast": "Password updated successfully.",
+      "errorToast": "Update failed. Please try again."
+    },
     "layout": {
       "headline": "Your AI-Powered",
       "headlineAccent": "Portfolio Command Center",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -72,6 +72,26 @@
       "hasAccount": "すでにアカウントをお持ちの方は",
       "signIn": "サインイン"
     },
+    "forgotPassword": {
+      "title": "パスワードをリセット",
+      "subtitle": "登録済みのメールアドレスを入力してください",
+      "email": "メールアドレス",
+      "submit": "リセットメールを送信",
+      "sending": "送信中…",
+      "successToast": "メールを送信しました。受信トレイを確認してください。",
+      "errorToast": "メールの送信に失敗しました。再度お試しください。",
+      "backToSignIn": "サインインに戻る"
+    },
+    "resetPassword": {
+      "title": "新しいパスワードを設定",
+      "subtitle": "新しいパスワードを入力してください",
+      "newPassword": "新しいパスワード",
+      "confirmPassword": "パスワード（確認）",
+      "submit": "パスワードを更新",
+      "updating": "更新中…",
+      "successToast": "パスワードを更新しました。",
+      "errorToast": "更新に失敗しました。再度お試しください。"
+    },
     "layout": {
       "headline": "AIが支える",
       "headlineAccent": "ポートフォリオ管理センター",


### PR DESCRIPTION
## 概要

- sign-in ページの「パスワードをお忘れの方」リンクを有効化し、メールベースのパスワードリセットフローを実装した
- カード内でフォームをアニメーション切り替え（AnimatePresence）し、ページ遷移なしでメールアドレスを入力できる
- Supabase の PKCE フローで `/auth/callback` → `/reset-password` へ遷移し、新パスワードを設定できる
- 成否に関わらず同一のトーストを表示し、アカウント存在の情報漏洩（列挙攻撃）を防止した

## 主な変更内容

- **`sign-in-form.tsx`** — `view` state を追加し `ForgotPasswordForm` とのインライン切り替えを実装
- **`forgot-password-form.tsx`** — メールアドレス入力フォームを新規作成
- **`reset-password-form.tsx`** — 新パスワード設定フォームを新規作成
- **`app/[locale]/(auth)/reset-password/page.tsx`** — リセット専用ページを新規作成
- **`features/auth/server/auth.ts`** — `resetPasswordEmail` / `updatePassword` Server Action を追加
- **`features/auth/schemas/`** — `forgot-password.ts` / `reset-password.ts` Zod スキーマを追加
- **`messages/ja.json` / `en.json`** — `auth.forgotPassword` / `auth.resetPassword` i18n キーを追加
- **`.env.example`** — `NEXT_PUBLIC_SITE_URL` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password reset functionality allowing users to recover access by entering their email address and setting a new password.
  * Added localization support for password recovery flows in English and Japanese.

* **Configuration**
  * Added `NEXT_PUBLIC_SITE_URL` environment variable configuration for password reset email redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->