### PR TITLE
fix: cash アセットの価格取得と資産計算を修正

### DIFF
--- a/features/assets/hooks/use-asset-table.ts
+++ b/features/assets/hooks/use-asset-table.ts
@@ -45,6 +45,9 @@ export function useAssetsTable({ assets }: UseAssetsTableParams) {
     queryFn: async () => {
       const entries = await Promise.all(
         assets.map(async (asset) => {
+          if (asset.asset_type === "cash") {
+            return [asset.symbol, { price: null, prevClose: null }];
+          }
           try {
             const res = await fetch(
               `/api/yahoofinance/quote?symbol=${asset.symbol}`,

--- a/features/assets/hooks/use-total-asset-card.ts
+++ b/features/assets/hooks/use-total-asset-card.ts
@@ -19,6 +19,9 @@ export function useAssetReturn({ assets }: UseAssetReturnParams) {
     queryFn: async () => {
       const entries = await Promise.all(
         assets.map(async (asset) => {
+          if (asset.asset_type === "cash") {
+            return [asset.symbol, { price: null, prevClose: null }];
+          }
           try {
             const res = await fetch(
               `/api/yahoofinance/quote?symbol=${asset.symbol}`,
@@ -40,6 +43,7 @@ export function useAssetReturn({ assets }: UseAssetReturnParams) {
 
   // 总市值
   const totalValue = assets.reduce((acc, asset) => {
+    if (asset.asset_type === "cash") return acc + asset.total_cost;
     const price = quotes[asset.symbol]?.price;
     if (price != null && price > 0) {
       return acc + price * asset.total_quantity;
@@ -64,8 +68,9 @@ export function useAssetReturn({ assets }: UseAssetReturnParams) {
     return acc;
   }, 0);
 
-  // 前一日资产市值
+  // 前一日资产市值（现金价值不变，前日 = 当日 total_cost）
   const yesterdayValue = assets.reduce((acc, asset) => {
+    if (asset.asset_type === "cash") return acc + asset.total_cost;
     const prev = quotes[asset.symbol]?.prevClose;
     if (prev != null && prev > 0) return acc + prev * asset.total_quantity;
     return acc;


### PR DESCRIPTION
## 概要

- cash アセットに対して Yahoo Finance の API 呼び出しが発生していたバグを修正した
- 総資産額の計算で cash アセットが `total_cost` として正しく加算されるよう修正した
- 前日比計算で cash アセットの前日値を `total_cost`（変動なし）として扱うよう修正した

## 主な変更内容

- **`use-asset-table.ts`** — `asset_type === "cash"` の場合に API を呼ばず `{ price: null, prevClose: null }` を返すよう修正
- **`use-total-asset-card.ts`** — 同様に API スキップ処理を追加し、総資産額・前日比計算で cash を `total_cost` として扱うよう修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)