### PR TITLE
fix: パスワードリセットのリダイレクト・ロケール・認証フローを修正

### DIFF
--- a/features/auth/components/forgot-password-form.tsx
+++ b/features/auth/components/forgot-password-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { motion, AnimatePresence } from "motion/react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import {
@@ -29,6 +29,7 @@ interface ForgotPasswordFormProps {
 
 const ForgotPasswordForm = ({ onBack }: ForgotPasswordFormProps) => {
   const t = useTranslations("auth.forgotPassword");
+  const locale = useLocale();
   const {
     register,
     handleSubmit,
@@ -39,7 +40,7 @@ const ForgotPasswordForm = ({ onBack }: ForgotPasswordFormProps) => {
   });
 
   const onSubmit = async (data: ForgotPasswordFormValues) => {
-    await resetPasswordEmail(data.email);
+    await resetPasswordEmail(data.email, locale);
     toast.success(t("successToast"));
     onBack();
   };

--- a/features/auth/server/auth.ts
+++ b/features/auth/server/auth.ts
@@ -99,13 +99,13 @@ export async function changePassword(currentPassword: string, newPassword: strin
   return { success: true };
 }
 
-export async function resetPasswordEmail(email: unknown) {
+export async function resetPasswordEmail(email: unknown, locale: string = "ja") {
   const result = forgotPasswordSchema.safeParse({ email });
   if (!result.success) return { error: "Invalid email" };
 
   const supabase = await createClient();
   const { error } = await supabase.auth.resetPasswordForEmail(result.data.email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/ja/reset-password`,
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=/${locale}/reset-password`,
   });
 
   if (error) return { error: "Failed to send reset email." };

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -53,6 +53,7 @@ export async function updateSession(request: NextRequest) {
     !isLocaleRoot &&
     !pathname.includes("/sign-in") &&
     !pathname.includes("/sign-up") &&
+    !pathname.includes("/reset-password") &&
     !pathname.startsWith("/auth/")
   ) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## 概要

- ミドルウェアに `/reset-password` を認証不要ページとして追加し、リカバリーセッション中のサインインへの誤リダイレクトを防止
- `resetPasswordEmail` に `locale` パラメータを追加し、ユーザーが使用中の言語でリセットページに遷移するよう修正
- `ForgotPasswordForm` で `useLocale` を使用して現在のロケールをサーバーアクションに渡すよう修正

## 修正前の問題

- SMS のリンクをクリックすると `/ja/sign-in?error=oauth_callback_error` にリダイレクトされた
  - 原因: ミドルウェアがリカバリーセッションのリフレッシュトークンを無効と判定し、認証済みページへのアクセスを拒否していた
- 英語ページからパスワードリセットを行うと、リセットページが日本語で表示された
  - 原因: `redirectTo` の URL に `/ja/reset-password` がハードコードされていた


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password reset functionality now supports multiple languages and locales, automatically delivering recovery emails with region-specific redirect links based on the user's current locale

* **Bug Fixes**
  * Resolved access control restrictions that prevented unauthenticated users from accessing password reset recovery pages
  * Password reset email flow now respects user locale settings throughout the recovery process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->