### PR TITLE
fix: フォント整理と検索UIの二重アイコンを修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, JetBrains_Mono } from "next/font/google";
+import { JetBrains_Mono, Playfair_Display } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -10,14 +10,10 @@ const jetbrainsMono = JetBrains_Mono({
   variable: "--font-sans",
 });
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const playfairDisplay = Playfair_Display({
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  variable: "--font-serif",
+  weight: ["400", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -31,10 +27,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja" className={jetbrainsMono.variable} suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="ja" className={`${jetbrainsMono.variable} ${playfairDisplay.variable}`} suppressHydrationWarning>
+      <body className="antialiased">
         <QueryProvider>
           <ThemeProvider
             attribute="class"

--- a/features/assets/components/symbol-search.tsx
+++ b/features/assets/components/symbol-search.tsx
@@ -3,7 +3,7 @@
 // 股票/加密货币符号实时搜索组件
 // 逻辑层见 hooks/use-symbol-search.ts
 
-import { Search, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import {
   Command,
   CommandEmpty,
@@ -28,19 +28,16 @@ export function SymbolSearch({ onSelect, defaultValue = "" }: Props) {
   return (
     <div className="relative">
       <Command className="border rounded-md" shouldFilter={false}>
-        <div className="flex items-center px-3">
-          {/* 搜索中显示 loading 动画，否则显示搜索图标 */}
-          {isFetching ? (
-            <Loader2 className="w-4 h-4 mr-2 animate-spin text-muted-foreground" />
-          ) : (
-            <Search className="w-4 h-4 mr-2 text-muted-foreground" />
-          )}
+        <div className="relative">
           <CommandInput
             placeholder="Search symbol or name..."
             value={query}
             onValueChange={setQuery}
             className="border-0 focus:ring-0"
           />
+          {isFetching && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-muted-foreground" />
+          )}
         </div>
 
         {/* 只在有搜索词时才显示下拉列表 */}


### PR DESCRIPTION
## 概要

未使用フォントの削除・Hero見出しのフォント正式化・資産追加ダイアログの検索UI修正を行いました。

## 主な変更点

- **未使用フォントの削除**：`Geist`・`Geist_Mono` はコード上でロードされていたものの、実際にはどのコンポーネントでも参照されていなかったため削除。不要なフォントリクエストを2本削減しました。
- **Playfair Display の追加**：`font-serif` クラスはこれまでブラウザデフォルトのserifフォント（OSによって異なる）に解決されており、環境間で表示が不一致でした。`Playfair Display`（Google Fonts）を `--font-serif` 変数に割り当て、Heroセクションの見出しに統一した表示を保証しました。
- **検索UIの二重アイコン修正**：`symbol-search.tsx` において `CommandInput`（shadcn/ui）が内部で検索アイコンを自動レンダリングするにもかかわらず、外側のラッパーでも手動で `<Search>` アイコンを追加していたため、アイコンが二重表示されていました。手動アイコンとラッパーを削除し、`CommandInput` の組み込みアイコンを利用するように修正。ローディング中の `Loader2` はインプット右端に絶対配置で維持しました。

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `app/layout.tsx` | `Geist`・`Geist_Mono` 削除、`Playfair_Display` 追加・`--font-serif` に割り当て |
| `features/assets/components/symbol-search.tsx` | 二重アイコン修正、未使用 `Search` import 削除 |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated application typography with refined font selections for improved visual consistency and overall design aesthetics.

* **New Features**
  * Enhanced the symbol search experience with a prominent loading indicator that displays while fetching results, providing clearer visual feedback during search operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cyoukakitsu/AI-Portfolio-Manager-Stocks-Crypto/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->