### PR TITLE
fix: カーソルスタイルの統一とカレンダーUIの修正

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none cursor-pointer",
   {
     variants: {
       variant: {

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
         ...formatters,
       }}
       classNames={{
-        root: cn("w-fit", defaultClassNames.root),
+        root: cn("w-full", defaultClassNames.root),
         months: cn(
           "flex gap-4 flex-col md:flex-row relative",
           defaultClassNames.months

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -37,7 +37,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-none p-2.5 text-xs shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden",
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-xl p-2.5 text-xs shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden",
             className
           )}
           {...props}

--- a/features/assets/components/asset-table.tsx
+++ b/features/assets/components/asset-table.tsx
@@ -104,6 +104,8 @@ export function AssetsTable({ assets }: Props) {
                       ease: "easeOut" as const,
                       delay: index * 0.04,
                     }}
+                    className="cursor-pointer"
+                    onClick={() => handleExpand(asset.id)}
                   >
                     <TableCell className="font-medium">
                       {asset.symbol}
@@ -170,7 +172,10 @@ export function AssetsTable({ assets }: Props) {
                         variant="ghost"
                         size="icon"
                         className="text-destructive hover:text-destructive"
-                        onClick={() => setDeletingAssetId(asset.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setDeletingAssetId(asset.id);
+                        }}
                       >
                         <Trash2 className="w-4 h-4" />
                       </Button>

--- a/features/assets/components/transaction-form.tsx
+++ b/features/assets/components/transaction-form.tsx
@@ -92,9 +92,7 @@ export function TransactionForm({
               render={({ field }) => (
                 <Tabs
                   value={field.value}
-                  onValueChange={(val) =>
-                    field.onChange(val as "buy" | "sell")
-                  }
+                  onValueChange={(val) => field.onChange(val as "buy" | "sell")}
                 >
                   <TabsList className="w-full">
                     <TabsTrigger value="buy" className="flex-1">
@@ -118,7 +116,7 @@ export function TransactionForm({
                     <div className="flex items-center border rounded-md h-8">
                       <button
                         type="button"
-                        className="px-3 h-full hover:bg-muted"
+                        className="px-3 h-full hover:bg-muted cursor-pointer"
                         // Math.max(1, ...) 防止数量减到 0 或负数
                         onClick={() =>
                           field.onChange(Math.max(1, Number(field.value) - 1))
@@ -145,7 +143,7 @@ export function TransactionForm({
                       />
                       <button
                         type="button"
-                        className="px-3 h-full hover:bg-muted"
+                        className="px-3 h-full hover:bg-muted cursor-pointer"
                         onClick={() => field.onChange(Number(field.value) + 1)}
                       >
                         <Plus className="w-4 h-4" />
@@ -164,7 +162,9 @@ export function TransactionForm({
                 render={({ field, fieldState }) => (
                   <Field data-invalid={fieldState.invalid} className="min-w-0">
                     <FieldLabel>
-                      {currentType === "buy" ? t("purchaseDate") : t("sellDate")}
+                      {currentType === "buy"
+                        ? t("purchaseDate")
+                        : t("sellDate")}
                     </FieldLabel>
                     <Popover>
                       <PopoverTrigger
@@ -215,7 +215,9 @@ export function TransactionForm({
                 render={({ field, fieldState }) => (
                   <Field data-invalid={fieldState.invalid} className="min-w-0">
                     <FieldLabel>
-                      {currentType === "buy" ? t("purchasePrice") : t("sellPrice")}
+                      {currentType === "buy"
+                        ? t("purchasePrice")
+                        : t("sellPrice")}
                     </FieldLabel>
                     <Input
                       type="number"


### PR DESCRIPTION
## 概要

クリック可能な要素全体のカーソルスタイル統一と、日付選択カレンダーのレイアウト・見た目を修正しました。

## 主な変更点

- **Button コンポーネントへの `cursor-pointer` 追加**：`components/ui/button.tsx` の `cva` 基底クラスに `cursor-pointer` を追加。プロジェクト内のすべての `Button` インスタンスに一括適用されます。`disabled:pointer-events-none` が既にあるため無効状態への影響はありません。
- **資産テーブル行のクリック展開対応**：`asset-table.tsx` の `MotionTableRow` に `onClick` と `cursor-pointer` を追加し、行全体をクリックして取引履歴を展開できるように変更。削除ボタンには `e.stopPropagation()` を追加し、行クリックと競合しないよう対処しました。
- **数量ボタンへの `cursor-pointer` 追加**：`transaction-form.tsx` の数量入力欄の `−` / `+` ネイティブ `<button>` に `cursor-pointer` を追加。
- **カレンダーの幅修正**：`calendar.tsx` の root クラスを `w-fit` → `w-full` に変更。日付グリッドが Popover コンテナ（`w-72`）いっぱいに広がり、左偏りが解消されます。
- **Popover の角丸化**：`popover.tsx` の `rounded-none` を `rounded-xl` に変更し、カレンダー等のポップオーバーに丸みを持たせました。

## 影響範囲

| ファイル | 変更内容 |
|---|---|
| `components/ui/button.tsx` | `cursor-pointer` を全 Button に一括適用 |
| `components/ui/calendar.tsx` | `w-fit` → `w-full` でカレンダー幅を Popover に合わせる |
| `components/ui/popover.tsx` | `rounded-none` → `rounded-xl` で角丸化 |
| `features/assets/components/asset-table.tsx` | 行クリックで展開・削除ボタンの伝播阻止 |
| `features/assets/components/transaction-form.tsx` | `−` / `+` ボタンに `cursor-pointer` 追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI & UX Improvements**
  * Calendar now displays at full width for better layout
  * Popover corners refined with rounded styling
  * Asset table rows made directly clickable to expand transaction details
  * Delete button interactions improved to prevent unintended row expansion
  * Form labels clarified for improved clarity
  * Enhanced button styling and cursor feedback across the interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cyoukakitsu/AI-Portfolio-Manager-Stocks-Crypto/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->